### PR TITLE
python 3.9 compability [need test]

### DIFF
--- a/unmanic/libs/foreman.py
+++ b/unmanic/libs/foreman.py
@@ -138,7 +138,7 @@ class Foreman(threading.Thread):
         thread_keys = [t for t in self.worker_threads]
         for thread in thread_keys:
             if thread in self.worker_threads:
-                if not self.worker_threads[thread].isAlive():
+                if not self.worker_threads[thread].is_alive():
                     del self.worker_threads[thread]
 
         # Check that we have enough workers running. Spawn new ones as required.
@@ -184,7 +184,7 @@ class Foreman(threading.Thread):
 
     def check_for_idle_workers(self):
         for thread in self.worker_threads:
-            if self.worker_threads[thread].idle and self.worker_threads[thread].isAlive():
+            if self.worker_threads[thread].idle and self.worker_threads[thread].is_alive():
                 if not self.worker_threads[thread].paused:
                     return True
         return False


### PR DESCRIPTION
change isAlive() to is_alive()

# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [x] I have ensured that my pull request is being opened to merge into the staging branch.

- [x] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request
[Python 3.9 changelog](https://docs.python.org/3/whatsnew/3.9.html)
The isAlive() method of threading.Thread has been removed. It was deprecated since Python 3.8. Use is_alive() instead. (Contributed by Dong-hee Na in bpo-37804.)
