### PR TITLE
[PLUGINS] Remove plugin module reload from executor

### DIFF
--- a/unmanic/libs/plugins.py
+++ b/unmanic/libs/plugins.py
@@ -512,8 +512,11 @@ class PluginsHandler(object, metaclass=SingletonType):
         records_by_id = self.get_plugin_list_filtered_and_sorted(id_list=plugin_table_ids)
 
         # Ensure they are now enabled
+        plugin_executor = PluginExecutor()
         for record in records_by_id:
             if record.get('enabled'):
+                # Reload the plugin module
+                plugin_executor.reload_plugin_module(record.get('plugin_id'))
                 continue
             self._log("Failed to enable plugin '{}'".format(record.get('plugin_id')), level='debug')
             return False

--- a/unmanic/libs/unplugins/executor.py
+++ b/unmanic/libs/unplugins/executor.py
@@ -143,7 +143,6 @@ class PluginExecutor(object):
 
         # Don't re-import the module if it is already loaded.
         if module_name in sys.modules:
-            # self.reload_plugin_module(plugin_id)
             return sys.modules[module_name]
 
         try:
@@ -265,9 +264,6 @@ class PluginExecutor(object):
         # Check if this module contains the given plugin type runner
         run_successfully = False
         if hasattr(plugin_module, plugin_runner):
-
-            # Reload the plugin
-            self.reload_plugin_module(plugin_id)
 
             # If it does, get the runner function
             runner = getattr(plugin_module, plugin_runner)


### PR DESCRIPTION
All these thredding issues where plugins would store configuration from a previous run should now be resolved.
Therefore it is time to remove this reload.
The only time we should be reloading the module is when it is enabled or uninstalled.

# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [x] I have ensured that my pull request is being opened to merge into the staging branch.

- [x] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request
