### PR TITLE
[DOCKER] Bump Jellyfin FFmpeg version to 5.1.3-1 and update runtime libs

### DIFF
--- a/devops/update-docker-packages.sh
+++ b/devops/update-docker-packages.sh
@@ -16,34 +16,15 @@ function docker_env {
 
 function print_updated_packages {
     runtime_packages=(
-        "libexpat1"
-        "libglib2.0-0"
-        "libgomp1"
-        "libharfbuzz0b"
         "libmediainfo0v5"
-        "libv4l-0"
-        "libx11-6"
-        "libxcb1"
-        "libxext6"
-        "libxml2"
     )
-    intel_media_driver_packages=(
-        "i965-va-driver"
+    intel_compute_runtime_packages=(
+        "libigdgmm12"
+        "libigdfcl1"
+        "libigc1"
+        "intel-opencl-icd"
         "intel-igc-cm"
         "intel-level-zero-gpu"
-        "intel-media-va-driver-non-free"
-        "intel-opencl-icd"
-        "level-zero"
-        "libgl1-mesa-dri"
-        "libigc1"
-        "libigdfcl1"
-        "libigdgmm11"
-        "libmfx1"
-        "libva-drm2"
-        "libva-wayland2"
-        "libva-x11-2"
-        "libva2"
-        "vainfo"
     )
 
     apt-get update
@@ -66,9 +47,9 @@ function print_updated_packages {
     echo
 
     echo
-    echo "Intel media driver package updates"
+    echo "Intel Compute Runtime package updates"
     echo
-    for package in ${intel_media_driver_packages[@]}; do
+    for package in ${intel_compute_runtime_packages[@]}; do
         update_version=$(cat /tmp/apt-updates.txt | grep "${package}/" | awk '{print $2}');
         if [[ -z ${update_version} ]]; then
             if [[ ${1:-X} == 'all' ]]; then

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,63 +4,37 @@ LABEL maintainer="Josh.5 <jsunnex@gmail.com>"
 
 # Env variables
 ENV \
-    LIBVA_DRIVERS_PATH="/usr/lib/x86_64-linux-gnu/dri" \
     NVIDIA_DRIVER_CAPABILITIES="compute,video,utility" \
     NVIDIA_VISIBLE_DEVICES="all"
 
 
 # Install the runtime dependencies
-# TODO: Remove intel-opencl-icd and replace with suggested build by Jellyfin
-#   https://jellyfin.org/docs/general/administration/hardware-acceleration.html
-#   https://github.com/jellyfin/jellyfin/blob/master/Dockerfile
+# jellyfin-ffmpeg5 comes with all VA-API drivers required by Intel and AMD, except the OpenCL runtime.
 RUN \
     echo "**** Install runtime packages ****" \
         && apt-get update \
         && apt-get install -y \
-            libexpat1=2.2.9-1ubuntu0.6 \
-            libglib2.0-0=2.64.6-1~ubuntu20.04.4 \
-            libgomp1=10.3.0-1ubuntu1~20.04 \
-            libharfbuzz0b=2.6.4-1ubuntu4.2 \
             libmediainfo0v5=19.09+dfsg-2build1 \
-            libv4l-0=1.18.0-2build1 \
-            libx11-6=2:1.6.9-2ubuntu1.2 \
-            libxcb1=1.14-2 \
-            libxext6=2:1.3.4-0ubuntu1 \
-            libxml2=2.9.10+dfsg-5ubuntu0.20.04.5 \
     && \
     echo "**** Install arch specific packages for $(uname -m) ****" \
         && sleep 2 \
         && \
-        if uname -m | grep -q x86; then \
-            echo "**** Add Intel Graphics repository  ****" \
+        if uname -m | grep -q x86_64; then \
+            echo "**** Add Intel Graphics repository ****" \
                 && apt-get install -y \
                     gnupg \
                 && echo "deb [arch=amd64] https://repositories.intel.com/graphics/ubuntu focal main" > /etc/apt/sources.list.d/intel-graphics.list \
                 && apt-key adv --fetch-keys https://repositories.intel.com/graphics/intel-graphics.key \
             && \
-            echo "**** Install Intel Media Drivers  ****" \
+            echo "**** Install Intel Compute Runtime ****" \
                 && apt-get update \
                 && apt-get install -y \
-                    i965-va-driver=2.4.0-0ubuntu1 \
-                    intel-igc-cm=1.0.160+i755~u20.04 \
-                    intel-level-zero-gpu=1.3.23726.1+i419~u20.04 \
-                    intel-media-va-driver-non-free=22.5.0+i419~u20.04 \
-                    intel-opencl-icd=22.28.23726.1+i419~u20.04 \
-                    level-zero=1.8.1+i755~u20.04 \
-                    libgl1-mesa-dri=22.2.0.20220625.1+3091 \
-                    libigc1=1.0.11485+i419~u20.04 \
+                    libigdgmm12=22.1.7+i419~u20.04 \
                     libigdfcl1=1.0.11485+i419~u20.04 \
-                    libigdgmm11=21.3.3+i643~u20.04 \
-                    libmfx1=22.5.0+i419~u20.04 \
-                    libva-drm2=2.15.0.2-36 \
-                    libva-wayland2=2.15.0.2-36 \
-                    libva-x11-2=2.15.0.2-36 \
-                    libva2=2.15.0.2-36 \
-                    vainfo=2.15.0.2-1 \
-            && \
-            echo "**** Install MESA Media Drivers for AMD VAAPI ****" \
-                && apt-get install -y \
-                    mesa-va-drivers=21.2.6-0ubuntu0.1~20.04.2 \
+                    libigc1=1.0.11485+i419~u20.04 \
+                    intel-igc-cm=1.0.160+i755~u20.04 \
+                    intel-opencl-icd=22.28.23726.1+i419~u20.04 \
+                    intel-level-zero-gpu=1.3.23726.1+i419~u20.04 \
             && \
             echo "**** Remove build packages ****" \
                 && apt-get remove -y \
@@ -79,29 +53,24 @@ RUN \
 
 
 # Install commonly used command line tools
-ARG JELLYFIN_FFMPEG_VERSION="4.4.1-4"
 ARG NODEJS_VERSION="16.x"
 RUN \
     echo "**** Install FFmpeg for $(uname -m) ****" \
         && sleep 2 \
         && apt-get update \
         && \
-        if uname -m | grep -q x86; then \
+        if uname -m | grep -q 'x86_64\|aarch64\|armv7l' ; then \
             echo "**** Add Jellyfin repository ****" \
                 && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg \
                 && curl -ks https://repo.jellyfin.org/jellyfin_team.gpg.key | apt-key add - \
                 && echo "deb [arch=$( dpkg --print-architecture )] https://repo.jellyfin.org/ubuntu focal main" | tee /etc/apt/sources.list.d/jellyfin.list \
             && \
-            echo "**** Install jellyfin-ffmpeg and linked 3rd party libs ****" \
+            echo "**** Install and link jellyfin-ffmpeg5 to ffmpeg ****" \
                 && apt-get update \
                 && apt-get install --no-install-recommends --no-install-suggests -y \
+                    jellyfin-ffmpeg5 \
+                    locales \
                     openssl \
-                    locales \
-                &&  curl -ksL \
-                    -o /tmp/jellyfin-ffmpeg_${JELLYFIN_FFMPEG_VERSION}-focal_amd64.deb \
-                    "https://repo.jellyfin.org/releases/server/ubuntu/versions/jellyfin-ffmpeg/${JELLYFIN_FFMPEG_VERSION}/jellyfin-ffmpeg_${JELLYFIN_FFMPEG_VERSION}-focal_amd64.deb" \
-                && apt-get install -y \
-                    /tmp/jellyfin-ffmpeg_${JELLYFIN_FFMPEG_VERSION}-focal_amd64.deb \
                 && ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg \
                 && ln -s /usr/lib/jellyfin-ffmpeg/ffprobe /usr/local/bin/ffprobe \
             && \
@@ -111,49 +80,11 @@ RUN \
             echo ; \
         fi \
         && \
-        if uname -m | grep -q aarch64; then \
-            echo "**** Install ffmpeg and linked 3rd party libs ****" \
-                && apt-get install --no-install-recommends --no-install-suggests -y \
-                    ffmpeg \
-                    libssl-dev \
-                    ca-certificates \
-                    libfontconfig1 \
-                    libfreetype6 \
-                    libomxil-bellagio0 \
-                    libomxil-bellagio-bin \
-                    locales \
+        if uname -m | grep -q x86_64 ; then \
+            echo "**** Link vainfo for x86_64 ****" \
+                && ln -s /usr/lib/jellyfin-ffmpeg/vainfo /usr/local/bin/vainfo \
             && \
-            echo ; \
-        fi \
-        && \
-        if uname -m | grep -q armv7l; then \
-            echo "**** Add Jellyfin repository ****" \
-                && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg \
-                && curl -ks https://repo.jellyfin.org/jellyfin_team.gpg.key | apt-key add - \
-                && curl -ks https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - \
-                && echo 'deb [arch=armhf] https://repo.jellyfin.org/ubuntu focal main' > /etc/apt/sources.list.d/jellyfin.list \
-                && echo "deb http://ppa.launchpad.net/ubuntu-raspi2/ppa/ubuntu bionic main">> /etc/apt/sources.list.d/raspbins.list \
-            && \
-            echo "**** Install jellyfin-ffmpeg and linked 3rd party libs ****" \
-                && apt-get update \
-                && apt-get install --no-install-recommends --no-install-suggests -y \
-                    jellyfin-ffmpeg \
-                    libssl-dev \
-                    libfontconfig1 \
-                    libfreetype6 \
-                    libomxil-bellagio0 \
-                    libomxil-bellagio-bin \
-                    libraspberrypi0 \
-                    vainfo \
-                    libva2 \
-                    locales \
-                && ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg \
-                && ln -s /usr/lib/jellyfin-ffmpeg/ffprobe /usr/local/bin/ffprobe \
-            && \
-            echo "**** Remove build packages ****" \
-                && apt-get remove -y gnupg \
-            && \
-            echo ; \
+            echo ; \				
         fi \
     && \
     echo "**** Install startup script requirements ****" \
@@ -195,32 +126,21 @@ RUN \
         && \
         echo "**** Install python ****" \
             && apt-get install -y --no-install-recommends \
+                gcc \
                 grc \
                 python3 \
+                python3-dev \
                 python3-pip \
                 python3-setuptools \
                 unzip \
         && \
-        if uname -m | grep -q armv7l; then \
-            echo "**** Install python package build dependencies ****" \
-                && apt-get install --no-install-recommends --no-install-suggests -y \
-                    gcc \
-                    python3-dev \
-            && \
-            echo ; \
-        fi \
-        && \
-        if uname -m | grep -q aarch64; then \
-            echo "**** Install python package build dependencies ****" \
-                && apt-get install --no-install-recommends --no-install-suggests -y \
-                    gcc \
-                    python3-dev \
-            && \
-            echo ; \
-        fi \
-        && \
         echo "**** Install pip packages ****" \
             && python3 -m pip install --no-cache-dir -r /tmp/requirements.txt \
+        && \
+        echo "**** Remove build packages ****" \
+            && apt-get remove -y \
+                gcc \
+                python3-dev \
     && \
     echo "**** Section cleanup ****" \
         && apt-get clean autoclean -y \


### PR DESCRIPTION
[Someone on reddit](https://www.reddit.com/r/jellyfin/comments/12tijk6/is_there_meaningful_difference_between_ffmpeg_and/) let me know that Unmanic is using an outdated jellyfin-ffmpeg. So here comes a PR to update it.

Btw the outdated Mesa and Intel libs from Ubuntu repo are not required anymore since our deb package comes with the latest one that used in our Jellyfin server.

And if anyone is interested in AV1 hardware encoding, you can give `jellyfin-ffmpeg6` a try.

# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [x] I have ensured that my pull request is being opened to merge into the staging branch.

- [x] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request

fixes #396 #384

```
root@ceb94c106c63:/# ffmpeg -v verbose -init_hw_device vaapi=va -init_hw_device qsv@va -init_hw_device opencl@va -init_hw_device vulkan@va
ffmpeg version 5.1.3-Jellyfin Copyright (c) 2000-2022 the FFmpeg developers
  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
  configuration: --prefix=/usr/lib/jellyfin-ffmpeg --target-os=linux --extra-libs=-lfftw3f --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-ptx-compression --disable-static --disable-libxcb --disable-sdl2 --disable-xlib --enable-lto --enable-gpl --enable-version3 --enable-shared --enable-gmp --enable-gnutls --enable-chromaprint --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libopenmpt --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265 --enable-libzvbi --enable-libzimg --enable-libfdk-aac --arch=amd64 --enable-libsvtav1 --enable-libshaderc --enable-libplacebo --enable-vulkan --enable-opencl --enable-vaapi --enable-amf --enable-libmfx --enable-ffnvcodec --enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvdec --enable-nvenc
  libavutil      57. 28.100 / 57. 28.100
  libavcodec     59. 37.100 / 59. 37.100
  libavformat    59. 27.100 / 59. 27.100
  libavdevice    59.  7.100 / 59.  7.100
  libavfilter     8. 44.100 /  8. 44.100
  libswscale      6.  7.100 /  6.  7.100
  libswresample   4.  7.100 /  4.  7.100
  libpostproc    56.  6.100 / 56.  6.100
[AVHWDeviceContext @ 0x556f1ac9ac80] Trying to use DRM render node for device 0.
[AVHWDeviceContext @ 0x556f1ac9ac80] libva: VA-API version 1.18.0
[AVHWDeviceContext @ 0x556f1ac9ac80] libva: Trying to open /usr/lib/jellyfin-ffmpeg/lib/dri/iHD_drv_video.so
[AVHWDeviceContext @ 0x556f1ac9ac80] libva: Found init function __vaDriverInit_1_18
[AVHWDeviceContext @ 0x556f1ac9ac80] libva: va_openDriver() returns 0
[AVHWDeviceContext @ 0x556f1ac9ac80] Initialised VAAPI connection: version 1.18
[AVHWDeviceContext @ 0x556f1ac9ac80] VAAPI driver: Intel iHD driver for Intel(R) Gen Graphics - 23.1.6 (8589406).
[AVHWDeviceContext @ 0x556f1ac9ac80] Driver not found in known nonstandard list, using standard behaviour.
[AVHWDeviceContext @ 0x556f1acc9180] Initialize MFX session: API version is 1.35, implementation version is 1.255
[AVHWDeviceContext @ 0x556f1adbc8c0] 0.0: Intel(R) OpenCL HD Graphics / Intel(R) Graphics [0x56a5]
[AVHWDeviceContext @ 0x556f1adbc8c0] Intel QSV to OpenCL mapping function found (clCreateFromVA_APIMediaSurfaceINTEL).
[AVHWDeviceContext @ 0x556f1adbc8c0] Intel QSV in OpenCL acquire function found (clEnqueueAcquireVA_APIMediaSurfacesINTEL).
[AVHWDeviceContext @ 0x556f1adbc8c0] Intel QSV in OpenCL release function found (clEnqueueReleaseVA_APIMediaSurfacesINTEL).
[AVHWDeviceContext @ 0x556f1adbf980] Supported validation layers:
[AVHWDeviceContext @ 0x556f1adbf980]    VK_LAYER_MESA_device_select
[AVHWDeviceContext @ 0x556f1adbf980]    VK_LAYER_MESA_overlay
[AVHWDeviceContext @ 0x556f1adbf980] GPU listing:
[AVHWDeviceContext @ 0x556f1adbf980]     0: Intel(R) Arc(tm) A380 Graphics (DG2) (discrete) (0x56a5)
[AVHWDeviceContext @ 0x556f1adbf980] Requested vendor: 0x8086
[AVHWDeviceContext @ 0x556f1adbf980] Device 0 selected: Intel(R) Arc(tm) A380 Graphics (DG2) (discrete) (0x56a5)
[AVHWDeviceContext @ 0x556f1adbf980] Queue families:
[AVHWDeviceContext @ 0x556f1adbf980]     0: graphics compute transfer (queues: 1)
[AVHWDeviceContext @ 0x556f1adbf980] Using device extension VK_KHR_push_descriptor
[AVHWDeviceContext @ 0x556f1adbf980] Using device extension VK_KHR_sampler_ycbcr_conversion
[AVHWDeviceContext @ 0x556f1adbf980] Using device extension VK_KHR_synchronization2
[AVHWDeviceContext @ 0x556f1adbf980] Using device extension VK_KHR_external_memory_fd
[AVHWDeviceContext @ 0x556f1adbf980] Using device extension VK_EXT_external_memory_dma_buf
[AVHWDeviceContext @ 0x556f1adbf980] Using device extension VK_EXT_image_drm_format_modifier
[AVHWDeviceContext @ 0x556f1adbf980] Using device extension VK_KHR_external_semaphore_fd
[AVHWDeviceContext @ 0x556f1adbf980] Using device extension VK_EXT_external_memory_host
[AVHWDeviceContext @ 0x556f1adbf980] Using device: Intel(R) Arc(tm) A380 Graphics (DG2)
[AVHWDeviceContext @ 0x556f1adbf980] Alignments:
[AVHWDeviceContext @ 0x556f1adbf980]     optimalBufferCopyRowPitchAlignment: 128
[AVHWDeviceContext @ 0x556f1adbf980]     minMemoryMapAlignment:              4096
[AVHWDeviceContext @ 0x556f1adbf980]     minImportedHostPointerAlignment:    4096
[AVHWDeviceContext @ 0x556f1adbf980] Using queue family 0 (queues: 1) for graphics compute transfers
Hyper fast Audio and Video encoder
usage: ffmpeg [options] [[infile options] -i infile]... {[outfile options] outfile}...

Use -h to get full help or, even better, run 'man ffmpeg'

root@ceb94c106c63:/# vainfo
Trying display: drm
libva info: VA-API version 1.18.0
libva info: Trying to open /usr/lib/jellyfin-ffmpeg/lib/dri/iHD_drv_video.so
libva info: Found init function __vaDriverInit_1_18
libva info: va_openDriver() returns 0
vainfo: VA-API version: 1.18 (libva 2.18.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 23.1.6 (8589406)
vainfo: Supported profile and entrypoints
      VAProfileNone                   : VAEntrypointVideoProc
      VAProfileNone                   : VAEntrypointStats
      VAProfileMPEG2Simple            : VAEntrypointVLD
      VAProfileMPEG2Main              : VAEntrypointVLD
      VAProfileH264Main               : VAEntrypointVLD
      VAProfileH264Main               : VAEntrypointEncSliceLP
      VAProfileH264High               : VAEntrypointVLD
      VAProfileH264High               : VAEntrypointEncSliceLP
      VAProfileJPEGBaseline           : VAEntrypointVLD
      VAProfileJPEGBaseline           : VAEntrypointEncPicture
      VAProfileH264ConstrainedBaseline: VAEntrypointVLD
      VAProfileH264ConstrainedBaseline: VAEntrypointEncSliceLP
      VAProfileHEVCMain               : VAEntrypointVLD
      VAProfileHEVCMain               : VAEntrypointEncSliceLP
      VAProfileHEVCMain10             : VAEntrypointVLD
      VAProfileHEVCMain10             : VAEntrypointEncSliceLP
      VAProfileVP9Profile0            : VAEntrypointVLD
      VAProfileVP9Profile0            : VAEntrypointEncSliceLP
      VAProfileVP9Profile1            : VAEntrypointVLD
      VAProfileVP9Profile1            : VAEntrypointEncSliceLP
      VAProfileVP9Profile2            : VAEntrypointVLD
      VAProfileVP9Profile2            : VAEntrypointEncSliceLP
      VAProfileVP9Profile3            : VAEntrypointVLD
      VAProfileVP9Profile3            : VAEntrypointEncSliceLP
      VAProfileHEVCMain12             : VAEntrypointVLD
      VAProfileHEVCMain422_10         : VAEntrypointVLD
      VAProfileHEVCMain422_12         : VAEntrypointVLD
      VAProfileHEVCMain444            : VAEntrypointVLD
      VAProfileHEVCMain444            : VAEntrypointEncSliceLP
      VAProfileHEVCMain444_10         : VAEntrypointVLD
      VAProfileHEVCMain444_10         : VAEntrypointEncSliceLP
      VAProfileHEVCMain444_12         : VAEntrypointVLD
      VAProfileHEVCSccMain            : VAEntrypointVLD
      VAProfileHEVCSccMain            : VAEntrypointEncSliceLP
      VAProfileHEVCSccMain10          : VAEntrypointVLD
      VAProfileHEVCSccMain10          : VAEntrypointEncSliceLP
      VAProfileHEVCSccMain444         : VAEntrypointVLD
      VAProfileHEVCSccMain444         : VAEntrypointEncSliceLP
      VAProfileAV1Profile0            : VAEntrypointVLD
      VAProfileAV1Profile0            : VAEntrypointEncSliceLP
      VAProfileHEVCSccMain444_10      : VAEntrypointVLD
      VAProfileHEVCSccMain444_10      : VAEntrypointEncSliceLP
```