### PR TITLE
Wait for copy, avoid overlapping file events

### DIFF
--- a/tests/unit/test_eventmonitor.py
+++ b/tests/unit/test_eventmonitor.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+    unmanic.{{FILE_NAME}}
+ 
+    Written by:               Josh.5 <jsunnex@gmail.com>
+    Date:                     30 Dec 2023, (6:59 PM)
+ 
+    Copyright:
+           Copyright (C) Josh Sunnex - All Rights Reserved
+ 
+           Permission is hereby granted, free of charge, to any person obtaining a copy
+           of this software and associated documentation files (the "Software"), to deal
+           in the Software without restriction, including without limitation the rights
+           to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+           copies of the Software, and to permit persons to whom the Software is
+           furnished to do so, subject to the following conditions:
+  
+           The above copyright notice and this permission notice shall be included in all
+           copies or substantial portions of the Software.
+  
+           THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+           EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+           MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+           IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+           DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+           OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+           OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+import pytest
+from unittest.mock import patch
+from unmanic.libs.eventmonitor import EventHandler
+
+class TestEventMonitor(object):
+    def test_wait_for_file_stabilization_file_stable(self):
+        """
+        Test that confirms that True is returned when the file does not change size.
+        It should only check the file size twice and sleep once.
+        """
+        file_path = "/path/to/file.txt"
+        event_monitor = EventHandler([], 1, set())
+
+        with patch("os.path.getsize") as mock_getsize, \
+                patch("time.sleep") as mock_sleep:
+            mock_getsize.return_value = 100
+
+            result = event_monitor._wait_for_file_stabilization(file_path)
+
+            assert result is True
+            mock_getsize.assert_called_with(file_path)
+            assert mock_getsize.call_count == 2
+            assert mock_sleep.call_count == 1
+
+    def test_wait_for_file_stabilization_file_not_stable(self):
+        """
+        Test that the method wait waits for the file to stabilize if the size changes.
+        It should check the file size 4 times and sleep 3 times.
+        """
+        file_path = "/path/to/file.txt"
+        event_monitor = EventHandler([], 1, set())
+
+        with patch("os.path.getsize") as mock_getsize, \
+                patch("time.sleep") as mock_sleep:
+            mock_getsize.side_effect = [50, 100, 150, 150]
+
+            result = event_monitor._wait_for_file_stabilization(file_path)
+
+            assert result is True
+            assert mock_getsize.call_count == 4
+            assert mock_sleep.call_count == 3
+            mock_getsize.assert_called_with(file_path)
+
+    def test_wait_for_file_stabilization_file_deleted(self):
+        """
+        Test that the method raises an exception if the file is moved or deleted while being checked for stabilization.
+        """
+        file_path = "/path/to/file.txt"
+        event_monitor = EventHandler([], 1, set())
+
+        with patch("os.path.getsize") as mock_getsize, \
+                patch("time.sleep") as mock_sleep:
+            mock_getsize.side_effect = OSError
+
+            with pytest.raises(OSError):
+                event_monitor._wait_for_file_stabilization(file_path)
+
+            mock_getsize.assert_called_once_with(file_path)
+            mock_sleep.assert_not_called()
+
+    def test_wait_for_file_stabilization_timeout_reached(self):
+        """
+        Test that ensures the method will throw a TimeoutError if the timeout is reached.
+        Since each iteration requires a sleep of 1 second, the method should sleep once before raising the exception.
+        """
+        file_path = "/path/to/file.txt"
+        event_monitor = EventHandler([], 1, set())
+
+        with patch("os.path.getsize") as mock_getsize:
+            mock_getsize.side_effect = [100, 200, 300, 400]
+
+            with pytest.raises(TimeoutError):
+                event_monitor._wait_for_file_stabilization(file_path, timeout=0.5)
+
+            mock_getsize.assert_called_with(file_path)
+            assert mock_getsize.call_count == 1

--- a/tests/unit/test_eventmonitor.py
+++ b/tests/unit/test_eventmonitor.py
@@ -101,7 +101,7 @@ class TestEventMonitor(object):
             mock_getsize.side_effect = [100, 200, 300, 400]
 
             with pytest.raises(TimeoutError):
-                event_monitor._wait_for_file_stabilization(file_path, timeout=0.5)
+                event_monitor._wait_for_file_stabilization(file_path, timeout_seconds=0.1)
 
             mock_getsize.assert_called_with(file_path)
             assert mock_getsize.call_count == 1

--- a/tests/unit/test_eventmonitor.py
+++ b/tests/unit/test_eventmonitor.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-    unmanic.{{FILE_NAME}}
+    unmanic.test_eventmonitor.py
  
     Written by:               Josh.5 <jsunnex@gmail.com>
     Date:                     30 Dec 2023, (6:59 PM)

--- a/tests/unit/test_eventmonitor.py
+++ b/tests/unit/test_eventmonitor.py
@@ -33,6 +33,7 @@ import pytest
 from unittest.mock import patch
 from unmanic.libs.eventmonitor import EventHandler
 
+@pytest.mark.unittest
 class TestEventMonitor(object):
     def test_wait_for_file_stabilization_file_stable(self):
         """

--- a/unmanic/libs/eventmonitor.py
+++ b/unmanic/libs/eventmonitor.py
@@ -127,7 +127,7 @@ class EventHandler(FileSystemEventHandler):
                 return True  # File size is stable
 
             last_size = current_size
-            self._log("File still being written to, waiting.", level="debug")
+            self._log("File path '{}' still being written to, waiting.".format(file_path), level="debug")
             time.sleep(check_interval)
 
         return False  # Timeout reached

--- a/unmanic/libs/eventmonitor.py
+++ b/unmanic/libs/eventmonitor.py
@@ -122,17 +122,18 @@ class EventHandler(FileSystemEventHandler):
                 'library_id': self.library_id,
             })
 
-    def _wait_for_file_stabilization(self, file_path, timeout=180):
+    def _wait_for_file_stabilization(self, file_path, timeout_seconds=180):
         """
         Wait for the file to be fully written to disk (i.e., file size becomes stable).
         
         :param file_path: Path to the file to check.
+        :param timeout_seconds: Timeout in seconds.
         :raises: TimeoutError if file stabilization times out.
         """
         start_time = time.time()
         last_size = -1
 
-        while time.time() - start_time < timeout:
+        while time.time() - start_time < timeout_seconds:
             current_size = os.path.getsize(file_path)
 
             if last_size == current_size:

--- a/unmanic/libs/eventmonitor.py
+++ b/unmanic/libs/eventmonitor.py
@@ -114,7 +114,7 @@ class EventHandler(FileSystemEventHandler):
                 # Wait for file to be fully written to disk
                 self._wait_for_file_stabilization(event.src_path)
             except Exception as e:
-                self._log("An error occurred while waiting for file stabilization: {}".format(str(e)), level="error")
+                self._log(str(e), level="error")
                 with threading.Lock():
                     self.active_files.discard(event.src_path)  # Remove the file from the set
                 return
@@ -127,7 +127,7 @@ class EventHandler(FileSystemEventHandler):
     def _wait_for_file_stabilization(self, file_path, timeout_seconds=600):
         """
         Wait for the file to be fully written to disk (i.e., file size becomes stable).
-        
+
         :param file_path: Path to the file to check.
         :param timeout_seconds: Timeout in seconds.
         :raises: TimeoutError if file stabilization times out.

--- a/unmanic/libs/eventmonitor.py
+++ b/unmanic/libs/eventmonitor.py
@@ -114,19 +114,17 @@ class EventHandler(FileSystemEventHandler):
                     'library_id': self.library_id,
                 })
 
-    def _wait_for_file_stabilization(self, file_path, check_interval=1, timeout=30):
+    def _wait_for_file_stabilization(self, file_path):
         """
         Wait for the file to be fully written to disk (i.e., file size becomes stable).
         
         :param file_path: Path to the file to check.
-        :param check_interval: Interval in seconds to check the file size.
-        :param timeout: Timeout in seconds to give up waiting for file stabilization.
         :return: True if file is stable, False if timed out.
         """
         start_time = time.time()
         last_size = -1
 
-        while time.time() - start_time < timeout:
+        while time.time() - start_time < 180:
             try:
                 current_size = os.path.getsize(file_path)
             except OSError:
@@ -137,7 +135,7 @@ class EventHandler(FileSystemEventHandler):
 
             last_size = current_size
             self._log("File path '{}' still being written to, waiting.".format(file_path), level="debug")
-            time.sleep(check_interval)
+            time.sleep(1)
 
         return False  # Timeout reached
 

--- a/unmanic/libs/eventmonitor.py
+++ b/unmanic/libs/eventmonitor.py
@@ -115,6 +115,8 @@ class EventHandler(FileSystemEventHandler):
                 self._wait_for_file_stabilization(event.src_path)
             except Exception as e:
                 self._log("An error occurred while waiting for file stabilization: {}".format(str(e)), level="error")
+                with threading.Lock():
+                    self.active_files.discard(event.src_path)  # Remove the file from the set
                 return
 
             self.files_to_test.put({

--- a/unmanic/libs/eventmonitor.py
+++ b/unmanic/libs/eventmonitor.py
@@ -122,7 +122,7 @@ class EventHandler(FileSystemEventHandler):
                 'library_id': self.library_id,
             })
 
-    def _wait_for_file_stabilization(self, file_path, timeout_seconds=180):
+    def _wait_for_file_stabilization(self, file_path, timeout_seconds=600):
         """
         Wait for the file to be fully written to disk (i.e., file size becomes stable).
         


### PR DESCRIPTION
# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [x] I have ensured that my pull request is being opened to merge into the staging branch.

- [x] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


### Problem Statement:

During testing, it was observed that Unmanic would attempt to test/process files before they were fully written to disk. In my setup, file copying to shared/mounted drives can sometimes take a minute or two to complete.

Additionally, a single file copy was found to trigger multiple overlapping `created` and `modified` events. This caused the file monitoring system to repeatedly attempt testing the same file.

### Proposed Changes in This PR:

This PR aims to address these issues by implementing the following fixes:

1. **Event Listening Improvements**: Now listens for both `created` and `modified` events to accurately capture file changes across all test scenarios.
2. **Write-in-Progress Check**: Implements a check to avoid testing a file if it is still being written to. This prevents Unmanic from processing files prematurely.
3. **Thread Lock Usage**: Utilizes a thread lock to ensure that multiple overlapping events do not lead to redundant file testing.

# Before Changes

### Simulate a slow file copy

`rsync --inplace --bwlimit=39321 --progress ~/Movie.mkv ~/Code/unmanic-docker/library`

```
INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'created' event on file path '/library/Movie.mkv'
DEBUG:Unmanic.EventProcessor - [FORMATTED] - Detected event is for a directory. Ignoring...
INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'modified' event on file path '/library/Movie.mkv'
INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'modified' event on file path '/library/Movie.mkv'
```


### File system copy

`cp ~/Movie.mkv ~/Code/unmanic-docker/library`

```
INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'created' event on file path '/library/Movie.mkv'
DEBUG:Unmanic.EventProcessor - [FORMATTED] - Detected event is for a directory. Ignoring...
INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'modified' event on file path '/library/Movie.mkv'
INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'modified' event on file path '/library/Movie.mkv'
```


### Directly move a file

`mv Movie.mkv foo.mkv`

```
INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'created' event on file path '/library/foo.mkv'
DEBUG:Unmanic.EventProcessor - [FORMATTED] - Detected event is for a directory. Ignoring...
INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'modified' event on file path '/library/foo.mkv'
```


### Create a file

`touch hello.mkv`

```
INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'created' event on file path '/library/hello.mkv'
DEBUG:Unmanic.EventProcessor - [FORMATTED] - Detected event is for a directory. Ignoring...
```


### Modify a file

`echo "hello" >> hello.mkv`

```
INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'modified' event on file path '/library/hello.mkv'
```


### Create a new file by copying an existing

`cp foo.mkv new.mkv`

```
INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'created' event on file path '/library/new.mkv'
DEBUG:Unmanic.EventProcessor - [FORMATTED] - Detected event is for a directory. Ignoring...
INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'modified' event on file path '/library/new.mkv'
INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'modified' event on file path '/library/new.mkv'
```

# After Changes

### Simulate a slow file copy

`rsync --inplace --bwlimit=39321 --progress ~/Movie.mkv ~/Code/unmanic-docker/library`

```
2023-12-29T22:50:57:INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'created' event on file path '/library/Movie.mkv'
2023-12-29T22:50:57:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:50:58:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:50:59:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:51:00:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:51:01:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:51:02:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:51:03:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:51:04:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:51:05:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:51:06:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:51:07:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:51:08:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:51:09:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:51:10:DEBUG:Unmanic.EventProcessor - [FORMATTED] - Detected event is for a directory. Ignoring...
2023-12-29T22:51:10:DEBUG:Unmanic.EventProcessor - [FORMATTED] - Ignoring 'modified' event on file path '/library/Movie.mkv' due to other events
2023-12-29T22:51:11:DEBUG:Unmanic.Plugin.video_transcoder - File '/library/Movie.mkv' should be added to task list. Plugin found streams require processing.
2023-12-29T22:51:13:DEBUG:Unmanic.Task - [FORMATTED] - Created new task with ID: 1 for /library/Movie.mkv
2023-12-29T22:51:13:INFO:Unmanic.TaskHandler - [FORMATTED] - Adding inotify job to queue - /library/Movie.mkv
```


### File system copy

`cp ~/Movie.mkv ~/Code/unmanic-docker/library`


```
2023-12-29T22:51:37:INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'created' event on file path '/library/Movie.mkv'
2023-12-29T22:51:37:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:51:38:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/Movie.mkv' still being written to, waiting.
2023-12-29T22:51:39:DEBUG:Unmanic.EventProcessor - [FORMATTED] - Detected event is for a directory. Ignoring...
2023-12-29T22:51:39:DEBUG:Unmanic.EventProcessor - [FORMATTED] - Ignoring 'modified' event on file path '/library/Movie.mkv' due to other events
2023-12-29T22:51:40:DEBUG:Unmanic.Plugin.video_transcoder - File '/library/Movie.mkv' should be added to task list. Plugin found streams require processing.
2023-12-29T22:51:41:INFO:Unmanic.TaskHandler - [FORMATTED] - Skipping inotify job already in the queue - /library/Movie.mkv
```


### Directly move a file

`mv Movie.mkv foo.mkv`


```
2023-12-29T22:52:38:INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'created' event on file path '/library/foo.mkv'
2023-12-29T22:52:38:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/foo.mkv' still being written to, waiting.
2023-12-29T22:52:39:DEBUG:Unmanic.EventProcessor - [FORMATTED] - Detected event is for a directory. Ignoring...
2023-12-29T22:52:39:DEBUG:Unmanic.EventProcessor - [FORMATTED] - Ignoring 'modified' event on file path '/library/foo.mkv' due to other events
2023-12-29T22:52:41:DEBUG:Unmanic.Plugin.video_transcoder - File '/library/foo.mkv' should be added to task list. Plugin found streams require processing.
2023-12-29T22:52:41:DEBUG:Unmanic.Task - [FORMATTED] - Created new task with ID: 2 for /library/foo.mkv
2023-12-29T22:52:41:INFO:Unmanic.TaskHandler - [FORMATTED] - Adding inotify job to queue - /library/foo.mkv
```

### Create a file


`touch hello.mkv`

```
2023-12-29T22:53:05:INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'created' event on file path '/library/hello.mkv'
2023-12-29T22:53:05:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/hello.mkv' still being written to, waiting.
2023-12-29T22:53:06:DEBUG:Unmanic.EventProcessor - [FORMATTED] - Detected event is for a directory. Ignoring...
2023-12-29T22:53:09:DEBUG:Unmanic.Plugin.video_transcoder - File unable to be probed by FFProbe - '/library/hello.mkv'
```

### Modify a file

`echo "hello" >> hello.mkv`

```
2023-12-29T22:53:27:INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'modified' event on file path '/library/hello.mkv'
2023-12-29T22:53:27:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/hello.mkv' still being written to, waiting.
2023-12-29T22:53:30:DEBUG:Unmanic.Plugin.video_transcoder - File unable to be probed by FFProbe - '/library/hello.mkv'
```

### Create a new file by copying an existing

`cp foo.mkv new.mkv`

```
2023-12-29T22:53:57:INFO:Unmanic.EventProcessor - [FORMATTED] - Detected 'created' event on file path '/library/new.mkv'
2023-12-29T22:53:57:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/new.mkv' still being written to, waiting.
2023-12-29T22:53:58:DEBUG:Unmanic.EventProcessor - [FORMATTED] - File path '/library/new.mkv' still being written to, waiting.
2023-12-29T22:53:59:DEBUG:Unmanic.EventProcessor - [FORMATTED] - Detected event is for a directory. Ignoring...
2023-12-29T22:53:59:DEBUG:Unmanic.EventProcessor - [FORMATTED] - Ignoring 'modified' event on file path '/library/new.mkv' due to other events
2023-12-29T22:54:00:DEBUG:Unmanic.Plugin.video_transcoder - File '/library/new.mkv' should be added to task list. Plugin found streams require processing.
2023-12-29T22:54:02:DEBUG:Unmanic.Task - [FORMATTED] - Created new task with ID: 3 for /library/new.mkv
2023-12-29T22:54:02:INFO:Unmanic.TaskHandler - [FORMATTED] - Adding inotify job to queue - /library/new.mkv
```

