### PR TITLE
Revert "Update file monitor to only use "closed" event"

### DIFF
--- a/unmanic/libs/eventmonitor.py
+++ b/unmanic/libs/eventmonitor.py
@@ -93,7 +93,7 @@ class EventHandler(FileSystemEventHandler):
         getattr(self.logger, level)(message)
 
     def on_any_event(self, event):
-        if event.event_type == "closed":
+        if event.event_type in ["created", "closed"]:
             # Ensure event was not for a directory
             if event.is_directory:
                 self._log("Detected event is for a directory. Ignoring...", level="debug")


### PR DESCRIPTION
# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [x] I have ensured that my pull request is being opened to merge into the staging branch.

- [x] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request
This reverts a previously merged PR that after further testing on bare metal linux, Docker and MacOS the behavior is not consistent across all operating systems and runtimes. In some cases the file change is not picked up by just the `closed` filesystem event, which may explain why the original version of this code has both events.

This is to prevent breaking Unmanic for people who already rely on the file monitor.