### PR TITLE
Use re-entrant lock in Singleton metaclass

### DIFF
--- a/unmanic/libs/singleton.py
+++ b/unmanic/libs/singleton.py
@@ -31,7 +31,7 @@
 """
 import threading
 
-lock = threading.Lock()
+lock = threading.RLock()
 
 
 class SingletonType(type):


### PR DESCRIPTION
# Pull request

## CLA

- [x ] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [x ] I have ensured that my pull request is being opened to merge into the staging branch.

- [x ] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request

Constructors of singleton classes can hang if they attempt to create another singleton that does not already exist, because this lock can not be acquired:
https://github.com/Unmanic/unmanic/blob/15900f0eac823aaa945ed1692ac4688e1ad85037/unmanic/libs/singleton.py#L43
 This could happen here in the constructor of the `Links` class which could attempt to construct `Session` and `Config` objects:
 https://github.com/Unmanic/unmanic/blob/15900f0eac823aaa945ed1692ac4688e1ad85037/unmanic/libs/installation_link.py#L85
Using a re-entrant lock fixes this, as it can be acquired multiple times by the same thread.