### PR TITLE
Upgrade peewee_migrate to 1.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ schedule==1.2.2
 tornado==6.3.3
 marshmallow~=3.22
 peewee>=3.14.4
-peewee_migrate==1.6.1
+peewee_migrate==1.13.0
 psutil~=6.0.0
 requests>=2.28.2
 requests_toolbelt>=0.9.1

--- a/unmanic/libs/db_migrate.py
+++ b/unmanic/libs/db_migrate.py
@@ -99,7 +99,7 @@ class Migrations(object):
             with self.database.transaction():
                 for model in all_models:
                     self.migrator.create_table(model)
-                self.migrator.run()
+                self.migrator()
         except Exception:
             self.database.rollback()
             self.logger.exception("Initialising tables failed")
@@ -127,7 +127,7 @@ class Migrations(object):
                             try:
                                 with self.database.transaction():
                                     self.migrator.add_columns(model, **{field.name: field})
-                                    self.migrator.run()
+                                    self.migrator()
                             except Exception:
                                 self.database.rollback()
                                 self.logger.exception("Update failed")


### PR DESCRIPTION
# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [x] I have ensured that my pull request is being opened to merge into the staging branch.

- [x] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request
Per [peewee_migrate's README.md](https://github.com/klen/peewee_migrate?tab=readme-ov-file#dependency-note), the recommendation is to use `Peewee-Migrate>=1.12.1` for `Python 3.8+`. In https://github.com/klen/peewee_migrate/commit/ed7516ffd373883bba0305e4bbac4a9b7df274ec, the `run` function was renamed to `__call__` and a subsequent commit would update the `run` function to call a specified Python function.

This commit updates peewee_migrate to the latest version and fixes the behavior to run migrations.