### PR TITLE
Extend `render_plugin_api`

### DIFF
--- a/unmanic/libs/unplugins/plugin_types/frontend/plugin_api.py
+++ b/unmanic/libs/unplugins/plugin_types/frontend/plugin_api.py
@@ -42,6 +42,8 @@ class PluginAPI(PluginType):
     The 'data' object argument includes:
         content_type                    - The content type to be set when writing back to the browser.
         content                         - The content to print to the browser.
+        status                          - The HTTP status code for the response.
+        method                          - The request method.
         path                            - The path received after the '/unmanic/panel' path.
         uri                             - The request uri.
         query                           - The request query.
@@ -59,6 +61,14 @@ class PluginAPI(PluginType):
         "content":      {
             "required": True,
             "type":     dict,
+        },
+        "status":      {
+            "required": True,
+            "type":     int,
+        },
+        "method":      {
+            "required": False,
+            "type":     str,
         },
         "path":         {
             "required": False,
@@ -84,6 +94,8 @@ class PluginAPI(PluginType):
     test_data = {
         'content_type': 'application/json',
         'content':      {},
+        'status':       200,
+        'method':       "GET",
         'path':         "/webhook",
         'arguments':    {'param': [b'true'], 'foo': [b'ba']},
         'body':         {'param': [b'true'], 'foo': [b'ba']},

--- a/unmanic/webserver/plugins.py
+++ b/unmanic/webserver/plugins.py
@@ -116,6 +116,12 @@ class PluginAPIRequestHandler(tornado.web.RequestHandler):
     def post(self, path):
         self.handle_panel_request()
 
+    def delete(self, path):
+        self.handle_panel_request()
+
+    def put(self, path):
+        self.handle_panel_request()
+
     def handle_panel_request(self):
         path = list(filter(None, self.request.path.split('/')[4:]))
 

--- a/unmanic/webserver/plugins.py
+++ b/unmanic/webserver/plugins.py
@@ -129,6 +129,7 @@ class PluginAPIRequestHandler(tornado.web.RequestHandler):
         data = {
             'content_type': 'application/json',
             'content':      {},
+            'status':       200,
             'method':       self.request.method,
             'path':         "/" + "/".join(path),
             'uri':          self.request.uri,
@@ -170,6 +171,7 @@ class PluginAPIRequestHandler(tornado.web.RequestHandler):
 
     def render_data(self, data):
         self.set_header("Content-Type", data.get('content_type', 'application/json'))
+        self.set_status(data.get('status'))
         self.write(data.get('content'))
 
 

--- a/unmanic/webserver/plugins.py
+++ b/unmanic/webserver/plugins.py
@@ -123,6 +123,7 @@ class PluginAPIRequestHandler(tornado.web.RequestHandler):
         data = {
             'content_type': 'application/json',
             'content':      {},
+            'method':       self.request.method,
             'path':         "/" + "/".join(path),
             'uri':          self.request.uri,
             'query':        self.request.query,


### PR DESCRIPTION
# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [x] I have ensured that my pull request is being opened to merge into the staging branch.

- [x] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request

Extends `render_plugin_api`'s usefulness by
* making the HTTP method of requests (`GET`, `POST`, ...) available to plugins
* handling `PUT` and `DELETE` requests
* allowing plugins to set the HTTP status code
