### PR TITLE
Allow binding to a specific address

### DIFF
--- a/unmanic/config.py
+++ b/unmanic/config.py
@@ -54,6 +54,7 @@ class Config(object, metaclass=SingletonType):
     def __init__(self, config_path=None, **kwargs):
         # Set the default UI Port
         self.ui_port = 8888
+        self.ui_address = ''
 
         # Set default directories
         home_directory = common.get_home_dir()
@@ -118,6 +119,8 @@ class Config(object, metaclass=SingletonType):
         # Overwrite all other settings passed from command params
         if kwargs.get('port'):
             self.set_config_item('ui_port', kwargs.get('port'), save_settings=False)
+        if kwargs.get('address'):
+            self.set_config_item('ui_address', kwargs.get('address'), save_settings=False)
 
         # Apply settings to the unmanic logger
         self.__setup_unmanic_logger()
@@ -294,6 +297,14 @@ class Config(object, metaclass=SingletonType):
         :return:
         """
         return self.ui_port
+
+    def get_ui_address(self):
+        """
+        Get setting - ui_address
+
+        :return:
+        """
+        return self.ui_address
 
     def get_cache_path(self):
         """

--- a/unmanic/libs/uiserver.py
+++ b/unmanic/libs/uiserver.py
@@ -190,7 +190,7 @@ class UIServer(threading.Thread):
         )
 
         try:
-            self.server.listen(int(self.config.get_ui_port()))
+            self.server.listen(int(self.config.get_ui_port()), address=self.config.get_ui_address())
         except socket.error as e:
             self._log("Exception when setting WebUI port {}:".format(self.config.get_ui_port()), message2=str(e),
                       level="warning")

--- a/unmanic/service.py
+++ b/unmanic/service.py
@@ -363,6 +363,8 @@ def main():
                         help='Enable development against another unmanic support api')
     parser.add_argument('--port', nargs='?',
                         help='Specify the port to run the webserver on')
+    parser.add_argument('--address', nargs='?',
+                        help='Specify the address to listen on, to limit connections to a specific interface')
     # parser.add_argument('--unmanic_path', nargs='?',
     #                    help='Specify the unmanic configuration path instead of ~/.unmanic')
     args = parser.parse_args()
@@ -370,6 +372,7 @@ def main():
     # Configure application from args
     settings = config.Config(
         port=args.port,
+        address=args.address,
         unmanic_path=None
     )
 


### PR DESCRIPTION
# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [x] I have ensured that my pull request is being opened to merge into the staging branch.

- [x] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request
Allow specifying an address to listen on. Intended to let users limit what interfaces Unmanic can be accessed from on systems with multiple network adapters or VPN endpoints.

Closes #575.