### PR TITLE
fixes for linked instance local lib copy

### DIFF
--- a/unmanic/libs/installation_link.py
+++ b/unmanic/libs/installation_link.py
@@ -34,6 +34,8 @@ import os.path
 import queue
 import threading
 import time
+import shutil
+import re
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -1625,10 +1627,47 @@ class RemoteTaskManager(threading.Thread):
                 "Remote task #{} was successful, proceeding to download the completed file '{}'".format(remote_task_id,
                                                                                                         task_label),
                 level='debug')
+            self._log(
+                "Remote task abspath {} to be transferred".format(data.get('abspath')),
+                level='debug')
             if os.path.exists(data.get('abspath')):
                 # /library/tvshows/show_name/season/unmanic_remote_pending_library/file.mkv
                 task_cache_path = data.get('abspath')
                 self.current_task.cache_path = task_cache_path
+                self._log("abspath exists - task cache path: '{}'".format(task_cache_path), level='debug')
+                # need to get the file into the local instance /tmp/unmanic/unmanic_file_conversion... location
+                # the task_cache_path file is currently sitting in the library's unmanic_remote_pending_library directory
+                # with a different random string - reformulate the basename of the file with the correct random string
+                # and copy it to the local instance /tmp/unmanic/unmanic_file_conversion location
+                tcp_base = os.path.basename(task_cache_path)
+                match1 = re.search(r'-\w{5}-\d{10}', cache_directory)
+                if match1:
+                    correct_random_string = match1.group()
+                else:
+                    self._log("Unable to detect random_string pattern in main instance cache directory named '{}'".format(cache_directory), level='error')
+                    self.links.remove_task_from_remote_installation(self.installation_info, remote_task_id)
+                    self.__write_failure_to_worker_log()
+                    return False
+                match2 = re.search(r'-\w{5}-\d{10}', tcp_base)
+                if match2:
+                    incorrect_random_string = match2.group()
+                else:
+                    self._log("Unable to detect random_string pattern in remote library located directory named '{}'".format(task_cache_path), level='error')
+                    self.links.remove_task_from_remote_installation(self.installation_info, remote_task_id)
+                    self.__write_failure_to_worker_log()
+                    return False
+                new_tcp_base = tcp_base.split(incorrect_random_string)[0]
+                sfx = tcp_base.split(incorrect_random_string)[1]
+                correct_cache_file_path = os.path.join(cache_directory, new_tcp_base + correct_random_string + sfx)
+                self._log(f"...copying {task_cache_path} to {correct_cache_file_path}", level='debug')
+                try:
+                    output = shutil.copy(task_cache_path, correct_cache_file_path)
+                    if os.path.exists(output) and os.path.getsize(output) > 0:
+                        self._log("File successfully copied from remote library located cache to main instance cache at '{}'".format(output), level='info')
+                    else:
+                        self.__write_failure_to_worker_log()
+                except (FileNotFoundError, PermissionError, shutil.SameFileError):
+                    self.__write_failure_to_worker_log()
             else:
                 # Set the new file out as the extension may have changed
                 split_file_name = os.path.splitext(data.get('abspath'))
@@ -1636,6 +1675,7 @@ class RemoteTaskManager(threading.Thread):
                 self.current_task.set_cache_path(cache_directory, file_extension)
                 # Read the updated cache path
                 task_cache_path = self.current_task.get_cache_path()
+                self._log("task cache path: '{}'".format(task_cache_path), level='debug')
 
                 # Loop until we are able to upload the file to the remote installation
                 while not self.redundant_flag.is_set():

--- a/unmanic/libs/postprocessor.py
+++ b/unmanic/libs/postprocessor.py
@@ -347,13 +347,13 @@ class PostProcessor(threading.Thread):
                 if not capture_success:
                     raise Exception("Failed to copy back to network share")
             except:
-                 os.mkdir(cache_tdir)
-                 self.__copy_file(cache_path, os.path.join(cache_tdir, os.path.basename(cache_path)), [], 'DEFAULT', move=True)
-                 tdir = cache_tdir
+                os.mkdir(cache_tdir)
+                self.__copy_file(cache_path, os.path.join(cache_tdir, os.path.basename(cache_path)), [], 'DEFAULT', move=True)
+                tdir = cache_tdir
+            finally:
+                self._log(f"tdir: {tdir}", level='debug')
         else:
             self._log("Final cache file '{}' does not exist!".format(cache_path), level="warning")
-
-        self._log(f"tdir: {tdir}", level='debug')
 
         # Cleanup cache files
         self.__cleanup_cache_files(cache_path)


### PR DESCRIPTION
# Pull request

## CLA

- [ ] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [X] I have ensured that my pull request is being opened to merge into the staging branch.

- [X] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request
Fixes for using local library copy of file vs uploading file from main to linked instance.
- in both installation_link.py and postprocessor.py i had a situation in a log output where i used a variable before setting it - i've refactored the code slightly to accommodate a placement of the log line where that won't ocurr.
- in installation_link.py, the section of code that recognizes that the cache file on the linked instance was in the library needed to be updated to actually copy the file from the library located cache to the cache on the main instance where the main instance normally places files.  Otherwise, the main instance doesn't find the file.  This is due in part to the random strings used on the cache folders and files.  The file name created on the linked instance has a random string that was created on the linked instance.  The main instance doesn't recognize those random strings, but also, the file needs to be copied back into the main instance's normal cache location for tasks.   So, the changes in installation_link.py:
-capture the main instances random string from it's cache directory
-creates the main instance cache filename expected on the main instance
-copies the cache file written by the remote instance located in the library to this newly created filename
