### PR TITLE
Stop sending system logs on websocket close

### DIFF
--- a/unmanic/webserver/websocket.py
+++ b/unmanic/webserver/websocket.py
@@ -127,6 +127,7 @@ class UnmanicWebsocketHandler(tornado.websocket.WebSocketHandler):
         self.stop_workers_info()
         self.stop_pending_tasks_info()
         self.stop_completed_tasks_info()
+        self.stop_system_logs()
 
     def on_remote_message(self, message):
         if message is None:


### PR DESCRIPTION
# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [x] I have ensured that my pull request is being opened to merge into the staging branch.

- [x] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request
Currently, `UnmanicWebsocketHandler`s leak in some cases because they don't stop sending system logs when the socket closes. You can try this by refreshing `/unmanic/ui/settings-support` and watching unmanic's CPU usage grow.