### PR TITLE
Address issues with plugin reloading

### DIFF
--- a/unmanic/libs/unplugins/executor.py
+++ b/unmanic/libs/unplugins/executor.py
@@ -190,22 +190,23 @@ class PluginExecutor(object):
         # self.logger.debug("Reloading module '{}'".format(module_name))
 
         if module_name in sys.modules:
-            # Get all submodules
-            module_names = [module_name]
-            for m in sys.modules:
-                if plugin_id in m and m not in [plugin_id, module_name]:
-                    # Add to removal list
-                    module_names.append(m)
-            # Reload all imported modules or remove them if that fails
-            for mn in module_names:
-                try:
-                    importlib.reload(sys.modules[mn])
-                except ImportError:
-                    # The module's parent was probably not imported.
-                    # Delete it from sys.modules and carry on.
-                    # This will force it to be reloaded again
-                    self.logger.exception("Exception encountered while trying to reload module '%s'", module_name)
-                    del sys.modules[module_name]
+            # Unload all submodules
+            submodules = []
+            for mn in sys.modules:
+                if mn.startswith(plugin_id + ".") and mn != module_name:
+                    submodules.append(mn)
+            for mn in submodules:
+                del sys.modules[mn]
+
+            # Reload the plugin module, it will import its submodules as required.
+            try:
+                importlib.reload(sys.modules[module_name])
+            except ImportError:
+                # The module's parent was probably not imported.
+                # Delete it from sys.modules and carry on.
+                # This will force it to be reloaded again
+                self.logger.exception("Exception encountered while trying to reload module '%s'", module_name)
+                del sys.modules[module_name]
 
     @staticmethod
     def unload_plugin_module(plugin_id):


### PR DESCRIPTION
# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [x] I have ensured that my pull request is being opened to merge into the staging branch.

- [x] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request
Currently when reloading a plugin during a plugin update it is possible (or rather, likely) that a plugin (or one of its submodules) will receive an old version of a submodule via import.  (Since `<plugin id>.plugin` is reloaded before its submodules, this is pretty much guaranteed)

This PR changes it so that all submodules of a plugin are unloaded first and the plugin module is reloaded afterwards so that it cleanly imports its updated submodules.

I am not sure how much thought went into this initially, I have been running this change for some weeks now. The only issue that I could still see (regarding failing plugin updates that require a restart) is an updated dependency in the plugin's `site-packages`. Also, I don't think the final `reload` should throw an exception (it would mean someone unloaded `<plugin id>`), but I left it in for now.