### PR TITLE
unmanic pr-unmanic-special-chars

### DIFF
--- a/unmanic/libs/taskqueue.py
+++ b/unmanic/libs/taskqueue.py
@@ -237,6 +237,8 @@ class TaskQueue(object):
         # Fetch Task item matching the filters specified
         task_item = fetch_next_task_filtered('pending', sort_by=self.sort_by, sort_order=self.sort_order,
                                              local_only=local_only, library_names=library_names, library_tags=library_tags)
+        if task_item:
+            self.mark_item_in_progress(task_item)
         return task_item
 
     def get_next_processed_tasks(self):

--- a/unmanic/webserver/downloads.py
+++ b/unmanic/webserver/downloads.py
@@ -38,6 +38,7 @@ from tornado import iostream, web
 
 from unmanic.libs.singleton import SingletonType
 
+from urllib.parse import quote
 
 class DownloadsLinks(object, metaclass=SingletonType):
     _download_links = {}
@@ -90,7 +91,13 @@ class DownloadsHandler(web.RequestHandler):
             return
 
         self.set_header('Content-Type', 'application/octet-stream')
-        self.set_header('Content-Disposition', 'attachment; filename={}'.format(basename))
+        # self.set_header('Content-Disposition', 'attachment; filename={}'.format(basename))
+        ascii_basename = basename.encode('ascii', 'replace').decode()
+        self.set_header('Content-Disposition',
+            "attachment; filename=\"{}\"; filename*=UTF-8''{}".format(
+                ascii_basename,
+                quote(basename)
+            ))
 
         # Serve file download in 1MB chunks
         with open(abspath, 'rb') as f:


### PR DESCRIPTION
# Pull request

## CLA

- [X] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [X] I have ensured that my pull request is being opened to merge into the staging branch.

- [X] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request
This fixes 2 issues discovered in support thread [https://discord.com/channels/819327740279914516/1486071845470998658]:

1) tasks on a linked instance were being processed multiple times (or there was a possibility they would be processed multiple times) and is fixed by setting the task state to in_progress.  Note this fix is unrelated to the special characters problem discovered in the support thread, but was simply discovered in troubleshooting that issue.
2) the webserver's download.py module encodes HTTP response headers as latin-1, but if characters are outside of this spec, the download fails.  In Unmanic the header is being composed with the filename which contains non-latin-1 characters.  The fix is to encode the filename using RFC 6266 filename*=UTF-8'' encoding.