### PR TITLE
Db timeout

### DIFF
--- a/unmanic/libs/foreman.py
+++ b/unmanic/libs/foreman.py
@@ -111,7 +111,7 @@ class Foreman(threading.Thread):
             try:
                 library_config = Library(library.get('id'))
             except Exception as e:
-                self.logger.exception('Unable to fetch library config for ID', library.get('id'))
+                self.logger.exception('Unable to fetch library config for id %s', library.get('id'))
                 continue
             # Get list of enabled plugins with their settings
             enabled_plugins = []
@@ -665,7 +665,7 @@ class Foreman(threading.Thread):
                     except queue.Empty:
                         continue
                     except Exception as e:
-                        self.logger.exception('Exception when fetching completed task report from worker', str(e))
+                        self.logger.exception('Exception when fetching completed task report from worker %s', e)
 
                 # Set up the correct number of workers
                 if not self.abort_flag.is_set():
@@ -786,7 +786,7 @@ class Foreman(threading.Thread):
                             source_abspath = next_item_to_process.get_source_abspath()
                             task_library_name = next_item_to_process.get_task_library_name()
                         except Exception as e:
-                            self.logger.exception('Exception in fetching task details', str(e))
+                            self.logger.exception('Exception in fetching task details %s', e)
                             self.event.wait(3)
                             continue
 

--- a/unmanic/libs/unmodels/lib/basemodel.py
+++ b/unmanic/libs/unmodels/lib/basemodel.py
@@ -120,6 +120,7 @@ class Database:
                 pragmas=(
                     ('foreign_keys', 1),
                     ('journal_mode', 'wal'),
+                    ('busy_timeout', 5000)
                 )
             )
 


### PR DESCRIPTION
# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [x] I have ensured that my pull request is being opened to merge into the staging branch.

- [x] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request

this should fix two issues that i received when unmanic was processing many files too quickly. not exactly sure what the initial trigger was for it to happen but it kept happening when many files were being completed in quick succession, this `sqlite3.OperationalError: database is locked` error is thrown, server stops responding and after a while after a manual restart its thrown again consistently. 

- add `busy_timeout` to pragmas alleviate lock timeout
- fix `TypeError: not all arguments converted during string formatting` where not all arguments have a placeholder in the log string.


```
**** (entrypoint) Starting: /usr/bin/unmanic
2026-04-25T00:46:01:INFO:Unmanic.UnmanicLogging - Initialising file logger. All further logs should output to the 'unmanic.log' file
--- Logging error ---
Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/peewee.py", line 3322, in execute_sql
    cursor.execute(sql, params or ())
sqlite3.OperationalError: database is locked

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/unmanic/libs/foreman.py", line 664, in run
    task_item.set_status('processed')
  File "/opt/venv/lib/python3.12/site-packages/unmanic/libs/task.py", line 271, in set_status
    self.save()
  File "/opt/venv/lib/python3.12/site-packages/unmanic/libs/task.py", line 322, in save
    self.task.save()
  File "/opt/venv/lib/python3.12/site-packages/peewee.py", line 6956, in save
    rows = self.update(**field_dict).where(self._pk_expr()).execute()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/peewee.py", line 2036, in inner
    return method(self, database, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/peewee.py", line 2107, in execute
    return self._execute(database)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/peewee.py", line 2625, in _execute
    cursor = database.execute(self)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/peewee.py", line 3330, in execute
    return self.execute_sql(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/peewee.py", line 3320, in execute_sql
    with __exception_wrapper__:
  File "/opt/venv/lib/python3.12/site-packages/peewee.py", line 3088, in __exit__
    reraise(new_type, new_type(exc_value, *exc_args), traceback)
  File "/opt/venv/lib/python3.12/site-packages/peewee.py", line 196, in reraise
    raise value.with_traceback(tb)
  File "/opt/venv/lib/python3.12/site-packages/peewee.py", line 3322, in execute_sql
    cursor.execute(sql, params or ())
peewee.OperationalError: database is locked

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/handlers.py", line 73, in emit
    if self.shouldRollover(record):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/logging/handlers.py", line 196, in shouldRollover
    msg = "%s\n" % self.format(record)
                   ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/logging/__init__.py", line 703, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/logging/__init__.py", line 392, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "/usr/lib/python3.12/threading.py", line 1030, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/opt/venv/lib/python3.12/site-packages/unmanic/libs/foreman.py", line 668, in run
    self.logger.exception('Exception when fetching completed task report from worker', str(e))
Message: 'Exception when fetching completed task report from worker'
Arguments: ('database is locked',)
```