### PR TITLE
Validate plugin zip members before extraction (zip-slip)

### DIFF
--- a/tests/unit/test_plugins_zip_safety.py
+++ b/tests/unit/test_plugins_zip_safety.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+    test_plugins_zip_safety.py
+
+    Tests for PluginsHandler._assert_zip_members_safe — ensures the plugin
+    install pipeline rejects zip-slip / symlink / absolute-path entries
+    before extraction.
+"""
+import os
+import stat
+import tempfile
+import zipfile
+
+import pytest
+
+from unmanic.libs.plugins import PluginsHandler
+
+
+def _make_zip(tmp_path, entries):
+    """Build a zip in tmp_path. Each entry is (name, data, external_attr)."""
+    zip_path = os.path.join(tmp_path, "plugin.zip")
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for name, data, external_attr in entries:
+            info = zipfile.ZipInfo(name)
+            if external_attr is not None:
+                info.external_attr = external_attr
+            zf.writestr(info, data)
+    return zip_path
+
+
+class TestAssertZipMembersSafe:
+
+    def test_safe_zip_passes(self, tmp_path):
+        dest = str(tmp_path / "dest")
+        os.makedirs(dest)
+        zip_path = _make_zip(str(tmp_path), [
+            ("info.json", b"{}", None),
+            ("plugin.py", b"# code", None),
+            ("static/index.html", b"<html/>", None),
+        ])
+        with zipfile.ZipFile(zip_path) as zf:
+            PluginsHandler._assert_zip_members_safe(zf, dest)
+
+    def test_parent_traversal_rejected(self, tmp_path):
+        dest = str(tmp_path / "dest")
+        os.makedirs(dest)
+        zip_path = _make_zip(str(tmp_path), [("../escape.txt", b"x", None)])
+        with zipfile.ZipFile(zip_path) as zf, pytest.raises(Exception, match="outside plugin directory"):
+            PluginsHandler._assert_zip_members_safe(zf, dest)
+
+    def test_deep_parent_traversal_rejected(self, tmp_path):
+        dest = str(tmp_path / "dest")
+        os.makedirs(dest)
+        zip_path = _make_zip(str(tmp_path), [("a/b/../../../etc/passwd", b"x", None)])
+        with zipfile.ZipFile(zip_path) as zf, pytest.raises(Exception, match="outside plugin directory"):
+            PluginsHandler._assert_zip_members_safe(zf, dest)
+
+    def test_absolute_posix_path_rejected(self, tmp_path):
+        dest = str(tmp_path / "dest")
+        os.makedirs(dest)
+        zip_path = _make_zip(str(tmp_path), [("/etc/passwd", b"x", None)])
+        with zipfile.ZipFile(zip_path) as zf, pytest.raises(Exception, match="absolute path"):
+            PluginsHandler._assert_zip_members_safe(zf, dest)
+
+    def test_windows_drive_path_rejected(self, tmp_path):
+        dest = str(tmp_path / "dest")
+        os.makedirs(dest)
+        zip_path = _make_zip(str(tmp_path), [("C:/Windows/evil.dll", b"x", None)])
+        with zipfile.ZipFile(zip_path) as zf, pytest.raises(Exception, match="absolute path"):
+            PluginsHandler._assert_zip_members_safe(zf, dest)
+
+    def test_symlink_entry_rejected(self, tmp_path):
+        dest = str(tmp_path / "dest")
+        os.makedirs(dest)
+        # external_attr encodes a symlink in the upper 16 bits as Unix file mode.
+        symlink_attr = (stat.S_IFLNK | 0o777) << 16
+        zip_path = _make_zip(str(tmp_path), [("link", b"../../etc", symlink_attr)])
+        with zipfile.ZipFile(zip_path) as zf, pytest.raises(Exception, match="symlink"):
+            PluginsHandler._assert_zip_members_safe(zf, dest)

--- a/unmanic/libs/plugins.py
+++ b/unmanic/libs/plugins.py
@@ -469,6 +469,32 @@ class PluginsHandler(object, metaclass=SingletonType):
                     f.write(chunk)
         return destination
 
+    @staticmethod
+    def _assert_zip_members_safe(zip_ref, dest_dir):
+        """
+        Validate every entry in a zip will extract to a path under ``dest_dir``.
+
+        Guards against zip-slip: archive members named with absolute paths,
+        ``..`` traversal, or symlinks that would let extraction escape the
+        plugin directory.
+        """
+        # Symlinks in zip archives are encoded in the upper 16 bits of
+        # external_attr as a Unix file mode. A symlink entry would let a
+        # later file be written through the link to an arbitrary path.
+        symlink_mode = 0o120000
+
+        dest_real = os.path.realpath(dest_dir)
+        for member in zip_ref.infolist():
+            name = member.filename
+            if (member.external_attr >> 16) & 0o170000 == symlink_mode:
+                raise Exception("Refusing to extract symlink entry from plugin zip: {}".format(name))
+            # Reject absolute paths and Windows drive-letter paths outright.
+            if name.startswith(('/', '\\')) or (len(name) >= 2 and name[1] == ':'):
+                raise Exception("Refusing to extract absolute path from plugin zip: {}".format(name))
+            target = os.path.realpath(os.path.join(dest_real, name))
+            if target != dest_real and not target.startswith(dest_real + os.sep):
+                raise Exception("Refusing to extract entry outside plugin directory: {}".format(name))
+
     def install_plugin(self, zip_file, plugin_id=None):
         """
         Install a given plugin from a zip file
@@ -491,6 +517,7 @@ class PluginsHandler(object, metaclass=SingletonType):
         # Extract zip file contents
         self.logger.debug("Extracting plugin to '{}'".format(plugin_directory))
         with zipfile.ZipFile(zip_file, "r") as zip_ref:
+            self._assert_zip_members_safe(zip_ref, str(plugin_directory))
             zip_ref.extractall(str(plugin_directory))
         # Read plugin info
         plugin_info = self.get_plugin_info(plugin_id)


### PR DESCRIPTION
## Summary

`PluginsHandler.install_plugin` calls `zipfile.extractall` on a downloaded or user-supplied plugin zip without validating member paths. A crafted archive containing entries with parent traversal (`../`), absolute paths, or symlinks could write files anywhere the Unmanic process can write — outside the plugin directory and at install time, before any plugin code runs.

This PR adds an up-front validation pass that rejects unsafe entries before extraction.

## Changes

- New `PluginsHandler._assert_zip_members_safe(zip_ref, dest_dir)` in `unmanic/libs/plugins.py`. For every entry it:
  - Rejects symlink entries (Unix file mode `0o120000` encoded in `external_attr`) — these would otherwise let a later file be written through the link to an arbitrary path.
  - Rejects POSIX absolute paths and Windows drive-letter paths.
  - Resolves the entry against `dest_dir` with `os.path.realpath` and confirms the result is contained within `dest_dir`. This catches both naive `../` traversal and paths that normalise back inside but escape via existing symlinks on disk.
- Called immediately before `extractall` in `install_plugin`.
- 6 unit tests in `tests/unit/test_plugins_zip_safety.py` covering safe input, parent traversal, deep traversal, POSIX absolute paths, Windows drive-letter paths, and symlink entries. (CI's pytest step is currently disabled, but they pass locally.)

## Test plan

- [x] `pytest tests/unit/test_plugins_zip_safety.py` — 6/6 pass
- [x] `flake8 unmanic/libs/plugins.py tests/unit/test_plugins_zip_safety.py --select=E9,F63,F7,F82` — clean
- [x] No behaviour change for well-formed plugin zips