### PR TITLE
Defer source removal in post_process_remote_file until delivery succeeds

### DIFF
--- a/tests/unit/test_postprocessor_remote.py
+++ b/tests/unit/test_postprocessor_remote.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+    test_postprocessor_remote.py
+
+    Tests for PostProcessor.post_process_remote_file — locks in the
+    invariant that the remote-source file is never removed unless the
+    processed file has been delivered to its destination.
+"""
+import logging
+import os
+
+import pytest
+
+from unmanic.libs.postprocessor import PostProcessor
+
+
+def _build_postprocessor(cache_root, dest_path, source_abspath, cache_path):
+    """Build a PostProcessor with just enough state to drive the remote path."""
+    pp = PostProcessor.__new__(PostProcessor)
+    pp.logger = logging.getLogger("test.postprocessor")
+    pp._last_destination_files = []
+    pp._last_file_move_processes_success = False
+
+    class _Settings:
+        def get_cache_path(self):
+            return str(cache_root)
+
+    class _Task:
+        def get_cache_path(self_inner):
+            return cache_path
+
+        def get_source_data(self_inner):
+            return {"abspath": source_abspath}
+
+        def get_destination_data(self_inner):
+            return {"abspath": dest_path}
+
+        def modify_path(self_inner, new_path):
+            self_inner.modified_to = new_path
+
+    pp.settings = _Settings()
+    pp.current_task = _Task()
+    return pp
+
+
+def _disable_cleanup(pp):
+    """Cache cleanup unlinks tmp dirs we want to inspect — neutralise it."""
+    pp._PostProcessor__cleanup_cache_files = lambda _path: None
+
+
+class TestPostProcessRemoteFile:
+
+    def test_source_retained_when_copy_to_cache_destination_fails(self, tmp_path):
+        """Headline case: cache-internal handoff that fails to copy must
+        not delete the source. Previously the source was removed first."""
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+        source = tmp_path / "source.mkv"
+        source.write_bytes(b"original")
+        cache_file = cache_root / "task-cache" / "processed.mkv"
+        cache_file.parent.mkdir()
+        cache_file.write_bytes(b"processed")
+        # Destination is inside the cache root, so remove_source_file is True.
+        destination = cache_root / "destination" / "out.mkv"
+
+        pp = _build_postprocessor(cache_root, str(destination), str(source), str(cache_file))
+        _disable_cleanup(pp)
+        # Force the copy to fail.
+        pp._PostProcessor__copy_file = lambda *args, **kwargs: False
+
+        pp.post_process_remote_file()
+
+        assert source.exists(), "source must be retained when delivery fails"
+        assert pp._last_file_move_processes_success is False
+        assert pp._last_destination_files == []
+
+    def test_source_removed_only_after_successful_copy(self, tmp_path):
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+        source = tmp_path / "source.mkv"
+        source.write_bytes(b"original")
+        cache_file = cache_root / "task-cache" / "processed.mkv"
+        cache_file.parent.mkdir()
+        cache_file.write_bytes(b"processed")
+        destination = cache_root / "destination" / "out.mkv"
+
+        pp = _build_postprocessor(cache_root, str(destination), str(source), str(cache_file))
+        _disable_cleanup(pp)
+        pp._PostProcessor__copy_file = lambda *args, **kwargs: True
+
+        pp.post_process_remote_file()
+
+        assert not source.exists(), "source must be removed once delivery succeeds"
+        assert pp._last_file_move_processes_success is True
+        assert pp._last_destination_files == [str(destination)]
+
+    def test_library_destination_keeps_source_regardless(self, tmp_path):
+        """When the destination is in the library (not the cache), the source
+        is always kept — copy success or failure does not change that."""
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+        library = tmp_path / "library"
+        library.mkdir()
+        source = library / "source.mkv"
+        source.write_bytes(b"original")
+        cache_file = cache_root / "task-cache" / "processed.mkv"
+        cache_file.parent.mkdir()
+        cache_file.write_bytes(b"processed")
+        destination = library / "out.mkv"  # outside cache_root
+
+        pp = _build_postprocessor(cache_root, str(destination), str(source), str(cache_file))
+        _disable_cleanup(pp)
+        pp._PostProcessor__copy_file = lambda *args, **kwargs: True
+
+        pp.post_process_remote_file()
+
+        assert source.exists(), "library source must always be retained"
+        assert pp._last_file_move_processes_success is True
+        assert pp._last_destination_files and pp._last_destination_files[0].endswith(
+            "processed.mkv")
+
+    def test_library_path_falls_back_to_cache_on_library_failure(self, tmp_path):
+        """If the library staging dir copy fails, the function falls back to
+        a cache-side staging dir and reports success."""
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+        library = tmp_path / "library"
+        library.mkdir()
+        source = library / "source.mkv"
+        source.write_bytes(b"original")
+        cache_file = cache_root / "task-cache" / "processed.mkv"
+        cache_file.parent.mkdir()
+        cache_file.write_bytes(b"processed")
+        destination = library / "out.mkv"
+
+        pp = _build_postprocessor(cache_root, str(destination), str(source), str(cache_file))
+        _disable_cleanup(pp)
+
+        # First call (library-side) fails, subsequent calls succeed.
+        calls = {"n": 0}
+
+        def fake_copy(*args, **kwargs):
+            calls["n"] += 1
+            return calls["n"] != 1
+
+        pp._PostProcessor__copy_file = fake_copy
+
+        pp.post_process_remote_file()
+
+        assert source.exists()
+        assert pp._last_file_move_processes_success is True
+        assert pp._last_destination_files
+        assert "cache" in pp._last_destination_files[0]
+
+    def test_both_staging_dirs_failing_reports_failure(self, tmp_path):
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+        library = tmp_path / "library"
+        library.mkdir()
+        source = library / "source.mkv"
+        source.write_bytes(b"original")
+        cache_file = cache_root / "task-cache" / "processed.mkv"
+        cache_file.parent.mkdir()
+        cache_file.write_bytes(b"processed")
+        destination = library / "out.mkv"
+
+        pp = _build_postprocessor(cache_root, str(destination), str(source), str(cache_file))
+        _disable_cleanup(pp)
+        pp._PostProcessor__copy_file = lambda *args, **kwargs: False
+
+        pp.post_process_remote_file()
+
+        assert source.exists()
+        assert pp._last_file_move_processes_success is False
+        assert pp._last_destination_files == []
+
+    def test_missing_cache_file_reports_failure(self, tmp_path):
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+        source = tmp_path / "source.mkv"
+        source.write_bytes(b"original")
+        cache_file = cache_root / "task-cache" / "processed.mkv"  # never created
+        destination = cache_root / "destination" / "out.mkv"
+
+        pp = _build_postprocessor(cache_root, str(destination), str(source), str(cache_file))
+        _disable_cleanup(pp)
+        # Sentinel: __copy_file should never be invoked when cache is missing.
+        pp._PostProcessor__copy_file = lambda *args, **kwargs: pytest.fail("__copy_file should not be called")
+
+        pp.post_process_remote_file()
+
+        assert source.exists()
+        assert pp._last_file_move_processes_success is False
+        assert pp._last_destination_files == []

--- a/unmanic/libs/postprocessor.py
+++ b/unmanic/libs/postprocessor.py
@@ -331,62 +331,102 @@ class PostProcessor(threading.Thread):
         destination_data = self.current_task.get_destination_data()
         def_cache_path = self.settings.get_cache_path()
 
-        remove_source_file = True
-        if def_cache_path not in destination_data['abspath']:
-            remove_source_file = False
+        # ``remove_source_file`` is True when the destination is itself inside
+        # the cache (a fully cache-internal handoff). False when the destination
+        # lives in the user's library, in which case the staged source download
+        # must be preserved.
+        remove_source_file = def_cache_path in destination_data['abspath']
 
         self._log(f"Cache path: {def_cache_path}", level='debug')
         self._log(
             f"Remote source: {source_data['abspath']}, destination file: {destination_data['abspath']}.", level='debug')
         self._log(f"Task cache path: {cache_path}", level='debug')
 
-        # Remove the source
-        if os.path.exists(source_data.get('abspath')) and remove_source_file:
-            self._log("Removing remote source: {}".format(source_data.get('abspath')))
-            os.remove(source_data.get('abspath'))
-        elif os.path.exists(source_data.get('abspath')) and not remove_source_file:
+        # Attempt to deliver the processed file. Source removal is deferred until
+        # a delivery has succeeded so a failed copy can never leave us with
+        # neither the source nor the destination.
+        move_success = False
+        final_destination = None
+
+        if not os.path.exists(cache_path):
+            self._log(
+                "Final cache file '{}' does not exist; nothing to deliver.".format(cache_path),
+                level="warning")
+        elif remove_source_file:
+            if self.__copy_file(cache_path, destination_data.get('abspath'), [], 'DEFAULT', move=True):
+                move_success = True
+                final_destination = destination_data.get('abspath')
+            else:
+                self._log(
+                    "Failed to move processed file '{}' to '{}'. Source will be retained.".format(
+                        cache_path, destination_data.get('abspath')),
+                    level="error")
+        else:
+            # Destination is in the library. Stage into a library-adjacent
+            # directory first so the user can move the file into place; if the
+            # library is unavailable, fall back to a cache-side staging dir.
+            random_string = '{}-{}'.format(common.random_string(), int(time.time()))
+            library_tdir = os.path.join(os.path.dirname(source_data.get('abspath')),
+                                        "unmanic_remote_pending_library-" + random_string)
+            cache_tdir = os.path.join(def_cache_path, "unmanic_remote_pending_library-" + random_string)
+
+            try:
+                os.mkdir(library_tdir)
+                library_target = os.path.join(library_tdir, os.path.basename(cache_path))
+                if self.__copy_file(cache_path, library_target, [], 'DEFAULT', move=True):
+                    move_success = True
+                    final_destination = library_target
+                else:
+                    raise Exception("Failed to copy back to library staging dir")
+            except Exception as e:
+                self._log(
+                    "Library-side staging failed ({}); falling back to cache.".format(e),
+                    level="warning")
+                try:
+                    os.mkdir(cache_tdir)
+                    cache_target = os.path.join(cache_tdir, os.path.basename(cache_path))
+                    if self.__copy_file(cache_path, cache_target, [], 'DEFAULT', move=True):
+                        move_success = True
+                        final_destination = cache_target
+                    else:
+                        self._log(
+                            "Cache-side staging also failed for '{}'.".format(cache_path),
+                            level="error")
+                except Exception as e2:
+                    self._log(
+                        "Cache-side staging directory could not be created ({}).".format(e2),
+                        level="error")
+
+        # Now that the delivery has either succeeded or definitively failed it
+        # is safe to drop the source. Removing it earlier would risk losing the
+        # only remaining copy of the file.
+        if not os.path.exists(source_data.get('abspath')):
+            self._log("Remote source file '{}' does not exist!".format(source_data.get('abspath')), level="warning")
+        elif not remove_source_file:
             self._log("Keep remote source: {}, remote file source is in library and not cache.".format(
                 source_data.get('abspath')))
-        else:
-            self._log("Remote source file '{}' does not exist!".format(source_data.get('abspath')), level="warning")
-
-        # Copy final cache file to original directory
-        random_string = '{}-{}'.format(common.random_string(), int(time.time()))
-        library_tdir = os.path.join(os.path.dirname(source_data.get('abspath')),
-                                    "unmanic_remote_pending_library-" + random_string)
-        cache_tdir = os.path.join(def_cache_path, "unmanic_remote_pending_library-" + random_string)
-
-        if os.path.exists(cache_path) and remove_source_file:
-            self.__copy_file(cache_path, destination_data.get('abspath'), [], 'DEFAULT', move=True)
-            tdir = cache_tdir
-        elif os.path.exists(cache_path) and not remove_source_file:
+        elif move_success:
+            self._log("Removing remote source: {}".format(source_data.get('abspath')))
             try:
-                tdir = library_tdir
-                os.mkdir(library_tdir)
-                capture_success = self.__copy_file(cache_path, os.path.join(
-                    library_tdir, os.path.basename(cache_path)), [], 'DEFAULT', move=True)
-                if not capture_success:
-                    raise Exception("Failed to copy back to network share")
-            except:
-                os.mkdir(cache_tdir)
-                self.__copy_file(cache_path, os.path.join(
-                    cache_tdir, os.path.basename(cache_path)), [], 'DEFAULT', move=True)
-                tdir = cache_tdir
-            finally:
-                self._log(f"tdir: {tdir}", level='debug')
+                os.remove(source_data.get('abspath'))
+            except OSError as e:
+                self._log(
+                    "Failed to remove remote source '{}': {}".format(source_data.get('abspath'), e),
+                    level="error")
         else:
-            self._log("Final cache file '{}' does not exist!".format(cache_path), level="warning")
+            self._log(
+                "Retaining remote source '{}' because the processed file was not delivered.".format(
+                    source_data.get('abspath')),
+                level="warning")
 
         # Cleanup cache files
         self.__cleanup_cache_files(cache_path)
-        self._last_destination_files = [self.current_task.get_destination_data().get('abspath')]
-        self._last_file_move_processes_success = True
+        self._last_file_move_processes_success = move_success
+        self._last_destination_files = [final_destination] if final_destination else []
 
         # Modify the task abspath - this may be different now
-        if remove_source_file:
-            self.current_task.modify_path(destination_data.get('abspath'))
-        else:
-            self.current_task.modify_path(os.path.join(tdir, os.path.basename(cache_path)))
+        if final_destination:
+            self.current_task.modify_path(final_destination)
 
     def __cleanup_cache_files(self, cache_path):
         """


### PR DESCRIPTION
> Retargeting from #616, which was closed; opening against `staging` per the project's contribution flow.

## Summary

`post_process_remote_file` removed the remote source file *before* attempting to copy the processed cache file to its destination. If the copy then failed (network share down, ENOSPC, permission denied, anything), the source was already gone and nothing took its place — total data loss for that task.

The function also discarded `__copy_file`'s return value and unconditionally set `_last_file_move_processes_success = True`, so downstream listeners (`postprocessor.task_result`, and the recently-added `postprocessor_complete` event) were told the delivery succeeded even when it had not. The library-side fallback used a bare `except:` that swallowed any exception (including `KeyboardInterrupt`) without logging.

## Changes

- Attempt the copy first; only remove the source after success. Move-success tracked from `__copy_file`'s return.
- `_last_file_move_processes_success` and `_last_destination_files` now reflect the actual outcome and the actual final path. `modify_path` is only called when something was delivered.
- Replaced the bare `except:` with `except Exception as e` and added log lines so the underlying failure is observable. Both library-side and cache-side fallback copies honour their `__copy_file` return value.
- Six unit tests in `tests/unit/test_postprocessor_remote.py`: cache-internal handoff success/failure (the headline regression), library destination keeping the source, library-to-cache fallback, both-fail reporting, and the missing-cache-file edge case.

## Test plan

- [x] `pytest tests/unit/test_postprocessor_remote.py` — 6/6 pass
- [x] `flake8 unmanic/libs/postprocessor.py tests/unit/test_postprocessor_remote.py --select=E9,F63,F7,F82` — clean
- [x] Behaviour for the success path matches the previous version — destination file at the same path, source removed when (and only when) it should be