### PR TITLE
update Docker file to install correct intel media driver

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,11 +90,14 @@ RUN \
         && sleep 2 \
         && \
         if uname -m | grep -q x86; then \
-            echo "**** Add Intel Graphics repository  ****" \
+            echo "**** Add Intel Graphics repository ****" \
+                && . /etc/os-release \
+                && INTEL_GPU_CODENAME="${VERSION_CODENAME:-noble}" \
+                && rm -f /etc/apt/sources.list.d/intel-gpu-*.list \
                 && wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg \
-                && echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy client" | tee /etc/apt/sources.list.d/intel-gpu-jammy.list \
+                && echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu ${INTEL_GPU_CODENAME} client" | tee /etc/apt/sources.list.d/intel-gpu.list \
             && \
-            echo "**** Install Intel Media Drivers  ****" \
+            echo "**** Install Intel Media Drivers ****" \
                 && apt-get update \
                 # intel-media-va-driver-non-free:
                 #   This is the primary driver for Intel's Video Acceleration API on Linux, which provides support for video encoding and decoding on Intel graphics hardware.


### PR DESCRIPTION
# Pull request

## CLA

- [X] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [X] I have ensured that my pull request is being opened to merge into the staging branch.

- [X] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request
the Dockerfile was hard coded to install the intel media driver from jammy, but the staging branch has been updated to noble, so it was installing an outdated intel media driver.  this fix modifies the Dockerfile RUN to read the release codename from /etc/os-release and uses that value to add the corresponding intel media repo and so the intel media driver installed matches the ubuntu release.