### PR TITLE
head/tail completed logs api

### DIFF
--- a/unmanic/webserver/api_v2/history_api.py
+++ b/unmanic/webserver/api_v2/history_api.py
@@ -371,7 +371,7 @@ class ApiHistoryHandler(BaseApiHandler):
         try:
             json_request = self.read_json_request(CompletedTasksLogRequestSchema())
 
-            command_log = completed_tasks.read_command_log_for_task(json_request.get('task_id'))
+            command_log = completed_tasks.read_command_log_for_task(json_request.get('task_id'), json_request.get('head'), json_request.get('tail'))
 
             response = self.build_response(
                 CompletedTasksLogSchema(),

--- a/unmanic/webserver/api_v2/schema/schemas.py
+++ b/unmanic/webserver/api_v2/schema/schemas.py
@@ -367,6 +367,16 @@ class CompletedTasksLogRequestSchema(BaseSchema):
         description="The ID of the task",
         example=1,
     )
+    head = fields.Int(
+        required=False,
+        description="Head rows to be included in log",
+        example=10,
+    )
+    tail = fields.Int(
+        required=False,
+        description="Tail rows to be included in log",
+        example=10,
+    )
 
 
 class CompletedTasksLogSchema(BaseSchema):

--- a/unmanic/webserver/helpers/completed_tasks.py
+++ b/unmanic/webserver/helpers/completed_tasks.py
@@ -210,7 +210,7 @@ def add_historic_tasks_to_pending_tasks_list(historic_task_ids, library_id=None)
     return errors
 
 
-def read_command_log_for_task(task_id):
+def read_command_log_for_task(task_id, head=None, tail=None):
     data = {
         'command_log':       '',
         'command_log_lines': [],
@@ -221,8 +221,13 @@ def read_command_log_for_task(task_id):
         return data
 
     for command_log in task_data.get('completedtaskscommandlogs_set', []):
-        data['command_log'] += command_log['dump']
-        data['command_log_lines'] += format_ffmpeg_log_text(command_log['dump'].split("\n"))
+        dump = command_log['dump'].split("\n")
+        head = len(dump) if head is None else head
+        tail = 0 if tail is None else tail
+        dump = dump[:head] + dump[len(dump)-tail:len(dump)]
+        
+        data['command_log'] += "\n".join(dump)
+        data['command_log_lines'] += format_ffmpeg_log_text(dump)
 
     return data
 


### PR DESCRIPTION
# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

- [x] I have ensured that my pull request is being opened to merge into the staging branch.

- [x] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request

Some tasks generate large log files.   Trying to access these via API or UI fails due to size of HTTP post result.   As a workaround to view a log file I have used script such as:

```
sqlite3 unmanic.db 'select dump from completedtaskscommandlogs where id = 889' | \
 awk 'NR <= 200 { print; next } { b[NR] = $0 } END { for(i = NR-20; i <= NR; i++) print b[i] }'
```

`id` is obtained from `unmanic/api/v2/history/tasks` end point.  This effectively displays 200 lines from start of log and 20 lines from end of log.  This makes it possible to debug failed tasks

To simplify process `unmanic/api/v2/history/task/log` end point has been extended with two additional optional attributes `head` and `tail`.  Being optional end point continues to work as is if only mandatory `task_id` is provided.

Front end has also been extended to make use of this API change.   This will be a separate PR as it's a different repo.  Current front end works with extended API end point.