### PR TITLE
Fix issue #627

### DIFF
--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+import pytest
+
+from unmanic.libs import plugins as plugins_module
+
+
+class DummyLogger:
+    def __getattr__(self, name):
+        return lambda *args, **kwargs: None
+
+
+def make_handler():
+    handler = plugins_module.PluginsHandler.__new__(plugins_module.PluginsHandler)
+    handler.logger = DummyLogger()
+    return handler
+
+
+def valid_repo_data():
+    return {
+        "repo": {"name": "Official Plugins", "repo_data_directory": "https://example.test/plugins"},
+        "plugins": [],
+    }
+
+
+@pytest.mark.unittest
+def test_default_repo_falls_back_to_direct_fetch_when_relay_returns_failure(monkeypatch):
+    class FailedRelaySession:
+        def get_installation_uuid(self):
+            return "installation"
+
+        def get_supporter_level(self):
+            return 0
+
+        def api_get(self, *args):
+            return {"messages": [], "success": False}, 200
+
+    response = SimpleNamespace(
+        raise_for_status=lambda: None,
+        json=valid_repo_data,
+    )
+    monkeypatch.setattr(plugins_module, "Session", FailedRelaySession)
+    monkeypatch.setattr(plugins_module.requests, "get", lambda *args, **kwargs: response)
+
+    result = make_handler().fetch_remote_repo_data("default")
+
+    assert result == valid_repo_data()
+
+
+@pytest.mark.unittest
+def test_failed_refresh_does_not_replace_existing_cache(monkeypatch, tmp_path):
+    handler = make_handler()
+    handler.settings = SimpleNamespace(get_plugins_path=lambda: str(tmp_path))
+    handler.get_plugin_repos = lambda: [{"path": "default"}]
+    handler.fetch_remote_repo_data = lambda repo_path: False
+
+    repo_cache = handler.get_repo_cache_file(handler.get_plugin_repo_id("default"))
+    with open(repo_cache, "w") as cache_file:
+        cache_file.write('{"repo": {"name": "cached"}, "plugins": []}')
+
+    assert handler.update_plugin_repos() is False
+    with open(repo_cache) as cache_file:
+        assert '"cached"' in cache_file.read()

--- a/unmanic/libs/plugins.py
+++ b/unmanic/libs/plugins.py
@@ -155,6 +155,28 @@ class PluginsHandler(object, metaclass=SingletonType):
             )
         if status_code >= 500:
             self.logger.debug(f"Failed to fetch plugin repo from '{api_path}'. Code:{status_code}")
+
+        if status_code >= 400:
+            remote_error = None
+            if isinstance(data, dict):
+                remote_error = data.get('error') or data.get('message')
+                if not remote_error and data.get('messages'):
+                    remote_error = data.get('messages')
+            remote_error = remote_error or f"HTTP {status_code}"
+            self.logger.error(
+                "Failed to fetch plugin repo '%s'. Code: %s. %s",
+                repo_path,
+                status_code,
+                remote_error,
+            )
+            return False
+
+        if not isinstance(data, dict) or not data.get('repo') or 'plugins' not in data:
+            self.logger.error(
+                "Failed to fetch plugin repo '%s'. Response did not contain valid repository data.",
+                repo_path,
+            )
+            return False
         return data
 
     def update_plugin_repos(self):
@@ -167,22 +189,27 @@ class PluginsHandler(object, metaclass=SingletonType):
         if not os.path.exists(plugins_directory):
             os.makedirs(plugins_directory)
         current_repos_list = self.get_plugin_repos()
+        update_successful = True
         for repo in current_repos_list:
             repo_path = repo.get('path')
             repo_id = self.get_plugin_repo_id(repo_path)
 
-            # Fetch remote JSON file
-            repo_data = self.fetch_remote_repo_data(repo_path)
-
-            # Dumb object to local JSON file
-            repo_cache = self.get_repo_cache_file(repo_id)
-            self.logger.info("Repo cache file '%s'.", repo_cache)
             try:
+                # Fetch remote JSON file
+                repo_data = self.fetch_remote_repo_data(repo_path)
+                if not repo_data:
+                    update_successful = False
+                    continue
+
+                # Dump object to local JSON file
+                repo_cache = self.get_repo_cache_file(repo_id)
+                self.logger.info("Repo cache file '%s'.", repo_cache)
                 with open(repo_cache, 'w') as f:
                     json.dump(repo_data, f, indent=4)
-            except json.JSONDecodeError as e:
-                self.logger.error("Unable to update plugin repo '%s'. %s", repo_path, str(e))
-        return True
+            except Exception as e:
+                update_successful = False
+                self.logger.exception("Exception while updating plugin repo '%s'. %s", repo_path, str(e))
+        return update_successful
 
     def get_settings_of_all_installed_plugins(self):
         all_settings = {}

--- a/unmanic/libs/plugins.py
+++ b/unmanic/libs/plugins.py
@@ -58,6 +58,7 @@ class PluginsHandler(object, metaclass=SingletonType):
     Plugins must be compatible with this version to be installed.
     """
     version: int = 2
+    DEFAULT_REPO_URL = "https://raw.githubusercontent.com/Unmanic/unmanic-plugins/repo/repo.json"
 
     def __init__(self, *args, **kwargs):
         self.settings = config.Config()
@@ -133,51 +134,62 @@ class PluginsHandler(object, metaclass=SingletonType):
         return True
 
     def fetch_remote_repo_data(self, repo_path):
-        # Fetch remote JSON file
         session = Session()
         uuid = session.get_installation_uuid()
         level = session.get_supporter_level()
         repo = base64.b64encode(repo_path.encode('utf-8')).decode('utf-8')
         api_path = f'plugin_repos/repo_data/uuid/{uuid}/level/{level}/repo/{repo}'
-        data, status_code = session.api_get(
-            'unmanic-api',
-            2,
-            api_path,
-        )
-        if status_code == 401:
-            # Something is wrong with registration. Let's resend it and try again.
-            self.logger.debug(f"Plugin repo returned a request to register. Code:{status_code}")
-            session.register_unmanic()
+        data = None
+        status_code = None
+        try:
             data, status_code = session.api_get(
                 'unmanic-api',
                 2,
                 api_path,
             )
-        if status_code >= 500:
-            self.logger.debug(f"Failed to fetch plugin repo from '{api_path}'. Code:{status_code}")
+            if status_code == 401:
+                self.logger.debug(f"Plugin repo returned a request to register. Code:{status_code}")
+                session.register_unmanic()
+                data, status_code = session.api_get(
+                    'unmanic-api',
+                    2,
+                    api_path,
+                )
+        except Exception as e:
+            self.logger.warning("Plugin repo relay failed for '%s': %s", repo_path, e)
 
-        if status_code >= 400:
-            remote_error = None
-            if isinstance(data, dict):
-                remote_error = data.get('error') or data.get('message')
-                if not remote_error and data.get('messages'):
-                    remote_error = data.get('messages')
-            remote_error = remote_error or f"HTTP {status_code}"
-            self.logger.error(
-                "Failed to fetch plugin repo '%s'. Code: %s. %s",
+        if self._valid_repo_data(data):
+            return data
+
+        remote_error = None
+        if isinstance(data, dict):
+            remote_error = data.get('error') or data.get('message')
+            if not remote_error and data.get('messages'):
+                remote_error = data.get('messages')
+        remote_error = remote_error or (f"HTTP {status_code}" if status_code else "invalid response")
+        direct_repo_path = self.DEFAULT_REPO_URL if repo_path == self.get_default_repo() else repo_path
+        if isinstance(direct_repo_path, str) and direct_repo_path.startswith(('http://', 'https://')):
+            self.logger.warning(
+                "Plugin repo relay returned no usable data for '%s' (%s); trying direct fetch.",
                 repo_path,
-                status_code,
                 remote_error,
             )
-            return False
+            try:
+                response = requests.get(direct_repo_path, timeout=10)
+                response.raise_for_status()
+                direct_data = response.json()
+                if self._valid_repo_data(direct_data):
+                    return direct_data
+                remote_error = "direct response did not contain valid repository data"
+            except Exception as e:
+                remote_error = f"direct fetch failed: {e}"
 
-        if not isinstance(data, dict) or not data.get('repo') or 'plugins' not in data:
-            self.logger.error(
-                "Failed to fetch plugin repo '%s'. Response did not contain valid repository data.",
-                repo_path,
-            )
-            return False
-        return data
+        self.logger.error("Failed to fetch plugin repo '%s': %s", repo_path, remote_error)
+        return False
+
+    @staticmethod
+    def _valid_repo_data(data):
+        return isinstance(data, dict) and data.get('repo') and 'plugins' in data
 
     def update_plugin_repos(self):
         """


### PR DESCRIPTION
# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership
of my work contained in that pull request to the Unmanic project and the project
owner. My contribution will become licensed under the same license as the overall
project. This extends upon paragraph 11 of the Terms & Conditions stipulated in
the GPL v3.0

## Checklist

- [x] I have ensured that my pull request is being opened to merge into the staging
branch.

- [x] I have ensured that all new python file contributions contain the correct
header as stipulated in the [Contributing Docs](CONTRIBUTING.md).

## Description of the pull request

Fix plugin repository refresh failures that caused the Plugin Installer to show
an empty installable plugin list.

The plugin repository relay can return an unsuccessful response or fail with an
HTTP error. Previously, that response could be treated as repository data and
cached, resulting in no installable plugins being displayed.

This change:

- Tries the Unmanic repository relay first.
- Falls back to fetching the official public repository directly if the relay
  fails or returns invalid data.
- Preserves existing valid cache data when a refresh fails.
- Adds regression tests for relay fallback and cache preservation.