### PR TITLE
Add authentication for the web UI and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Unmanic provides you with the following main functions:
 - A file/directory monitor. When a file is modified, or a new file is added in your library, Unmanic is able to again test that against your configured file presets. Like the first function, if this file requires processing, it is added to a queue for processing.
 - A handler to manage running multiple file manipulation tasks at a time.
 - A Web UI to easily configure, manage and monitor the progress of your library optimisation.
+- Optional [authentication](docs/AUTHENTICATION.md) for the Web UI and API, to keep other devices on your network out. Disabled by default.
 
 You choose how you want your library to be.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Unmanic provides you with the following main functions:
 - A file/directory monitor. When a file is modified, or a new file is added in your library, Unmanic is able to again test that against your configured file presets. Like the first function, if this file requires processing, it is added to a queue for processing.
 - A handler to manage running multiple file manipulation tasks at a time.
 - A Web UI to easily configure, manage and monitor the progress of your library optimisation.
-- Optional [authentication](docs/AUTHENTICATION.md) for the Web UI and API, to keep other devices on your network out. Disabled by default.
+- [Authentication](docs/AUTHENTICATION.md) for the Web UI and API, to keep other devices on your network out. Set up on first run for new installations, and opt-in for existing ones.
 
 You choose how you want your library to be.
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,0 +1,137 @@
+# Authentication
+
+Unmanic can require a username and password before anything on the web UI or API can be
+reached. It is **disabled by default**; enabling it is entirely opt-in, and no existing
+installation changes behaviour until you turn it on.
+
+## What this protects against, and what it does not
+
+This exists so that other devices and people on your local network cannot reach Unmanic.
+Without it, anyone who can route to the port can browse your filesystem, delete files from
+your library, and reconfigure your workers.
+
+**It does not make Unmanic safe to expose to the internet.** Unmanic runs ffmpeg against
+paths under its control and exposes a filesystem browser, so a single authentication bypass
+is a host compromise, not a nuisance. If you need access from outside your network, use a
+VPN or put Unmanic behind an authenticating reverse proxy. A password is not a substitute
+for either.
+
+Over plain HTTP, credentials are recoverable by anyone who can capture traffic on your
+network. If that is part of your threat model, enable TLS with the `ssl_enabled`,
+`ssl_certfilepath` and `ssl_keyfilepath` settings.
+
+## Turning it on
+
+### From the command line
+
+```bash
+unmanic --set-password
+```
+
+For Docker:
+
+```bash
+docker exec -it unmanic unmanic --set-password
+```
+
+Restart Unmanic afterwards.
+
+### With environment variables
+
+```yaml
+environment:
+  auth_enabled: "true"
+  auth_username: "your-username"
+  auth_password: "your-password"
+```
+
+The password is hashed at startup and is never written to `settings.json`. Note that
+environment variables are visible to anyone able to run `docker inspect` on the container.
+
+### From a browser
+
+Set `auth_enabled` to `true` and restart. Unmanic will serve a one-time setup page at
+`/unmanic/setup` for you to choose a username and password, and every other page redirects
+to it until you do. Until you complete it, anyone who can reach the installation can claim
+it, so do this straight away.
+
+## If you lock yourself out
+
+```bash
+unmanic --disable-auth
+```
+
+For Docker, `docker exec -it unmanic unmanic --disable-auth`. Then restart.
+
+## Signing out
+
+Signing out revokes that browser's session immediately. Changing your password revokes
+every session on every device.
+
+## API and remote installations
+
+Browsers use a session cookie. Scripts and linked Unmanic installations use HTTP Basic with
+the same username and password:
+
+```bash
+curl -u your-username:your-password http://your-host:8888/unmanic/api/v2/version/read
+```
+
+Remote installation links already support this: set the link's auth mode to `Basic` and fill
+in the username and password on the *Settings > Link* page of the installation doing the
+connecting.
+
+Basic authentication can be turned off with the `auth_allow_basic` setting if you only ever
+use a browser. Doing so will break remote installation links.
+
+## Settings reference
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `auth_enabled` | `false` | Master switch |
+| `auth_allow_basic` | `true` | Accept HTTP Basic on API requests |
+| `auth_session_idle_timeout_days` | `7` | Sign out after this long without activity |
+| `auth_session_max_age_days` | `30` | Absolute session lifetime |
+| `auth_trusted_origins` | `[]` | Extra origins accepted by the cross-origin check, for reverse proxies that rewrite `Host` |
+
+## Behind a reverse proxy
+
+If your proxy rewrites the `Host` header, the cross-origin protection will reject form
+submissions. Add the address you use in the browser to `auth_trusted_origins`, including the
+scheme:
+
+```json
+"auth_trusted_origins": ["https://unmanic.example.com"]
+```
+
+`X-Forwarded-Host` is deliberately not trusted, because anyone able to set that header could
+use it to defeat the check.
+
+## How it works
+
+For anyone reviewing or extending this:
+
+- **Passwords** are hashed with `hashlib.scrypt` (`n=32768, r=8, p=1`), stored as
+  `scrypt$n$r$p$salt$hash` so the parameters travel with the hash and can be raised later
+  without a migration. Credentials live in the database, not in `settings.json`, which is
+  routinely pasted into bug reports.
+- **Sessions** are 256-bit random tokens. Only their SHA-256 is stored, so a leaked database
+  yields nothing replayable. They carry a sliding idle timeout under an absolute cap.
+- **The session cookie** is `HttpOnly`, `SameSite=Lax`, and `Secure` only when TLS is
+  enabled - setting `Secure` over plain HTTP would stop the cookie being sent at all.
+- **Enforcement** happens in one place, `UnmanicWebApplication.find_handler`, so every route
+  is covered by construction: the REST API, the frontend, static assets, the WebSocket
+  handshake, the Swagger UI, and dynamically registered plugin handlers. An endpoint cannot
+  be left unprotected by forgetting a decorator.
+- **Cross-site protection** is `SameSite=Lax`, plus an `Origin` check on state-changing
+  requests, plus rejection of `Sec-Fetch-Site: cross-site` on `/unmanic/api/`,
+  `/unmanic/plugin_api/` and `/unmanic/panel/`. The third layer exists because `SameSite=Lax`
+  still attaches the cookie to top-level GET navigation and browsers do not send `Origin` on
+  those. An absent `Sec-Fetch-Site` header is allowed, because browsers do not send it on
+  WebSocket handshakes.
+- **`WWW-Authenticate` is never sent.** Browsers therefore never cache Basic credentials, so
+  Basic never becomes an ambient credential and never becomes a cross-site request forgery
+  vector. Machine clients such as `requests.HTTPBasicAuth` send credentials preemptively and
+  never need the challenge.
+- **Failed attempts** are throttled per client address with an escalating lockout, and logged
+  at warning level with the source address so tools like fail2ban have something to act on.

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,8 +1,15 @@
 # Authentication
 
 Unmanic can require a username and password before anything on the web UI or API can be
-reached. It is **disabled by default**; enabling it is entirely opt-in, and no existing
-installation changes behaviour until you turn it on.
+reached.
+
+**A new installation has this on.** The first time you open the web UI you are asked to choose
+a username and password, and nothing else is reachable until you do.
+
+**An existing installation is left alone.** If Unmanic has run before, it already has a
+settings file, and upgrading does not turn authentication on. Enabling it underneath a working
+installation would lock you out of your own system and break any remote instance links, so it
+stays off until you ask for it. Turning it on is described below.
 
 ## What this protects against, and what it does not
 
@@ -50,10 +57,13 @@ environment variables are visible to anyone able to run `docker inspect` on the 
 
 ### From a browser
 
-Set `auth_enabled` to `true` and restart. Unmanic will serve a one-time setup page at
-`/unmanic/setup` for you to choose a username and password, and every other page redirects
-to it until you do. Until you complete it, anyone who can reach the installation can claim
-it, so do this straight away.
+A new installation does this for you: authentication is already on, so the first page you open
+is the setup page at `/unmanic/setup`, and every other page redirects to it until you choose a
+username and password.
+
+On an existing installation, set `auth_enabled` to `true` and restart to get the same setup
+page. Until you complete it, anyone who can reach the installation can claim it, so do it
+straight away.
 
 ## If you lock yourself out
 
@@ -88,7 +98,7 @@ use a browser. Doing so will break remote installation links.
 
 | Setting | Default | Purpose |
 |---|---|---|
-| `auth_enabled` | `false` | Master switch |
+| `auth_enabled` | `true` on a new install, `false` on an upgrade | Master switch |
 | `auth_allow_basic` | `true` | Accept HTTP Basic on API requests |
 | `auth_session_idle_timeout_days` | `7` | Sign out after this long without activity |
 | `auth_session_max_age_days` | `30` | Absolute session lifetime |

--- a/tests/integration/test_webauth_api.py
+++ b/tests/integration/test_webauth_api.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import json
+import tempfile
+
+import pytest
+import requests
+
+from tests.support_.webauth_db import create_test_database, destroy_test_database
+from tests.support_.webauth_server import BackgroundServer
+from unmanic import config
+from unmanic.libs.uiserver import UnmanicWebApplication
+from unmanic.libs.unmodels.webauthcredentials import WebAuthCredentials
+from unmanic.libs.unmodels.webauthsessions import WebAuthSessions
+from unmanic.libs.webauth import credentials, sessions
+from unmanic.webserver.api_v2.auth_api import ApiAuthHandler
+
+MODELS = [WebAuthCredentials, WebAuthSessions]
+
+
+@pytest.mark.integrationtest
+class TestAuthApi(object):
+    def setup_method(self):
+        self.db = create_test_database(MODELS)
+        config.Config._instances = {}
+        self.settings = config.Config(config_path=tempfile.mkdtemp(prefix="unmanic_tests_"))
+        credentials.flush_verify_cache()
+        self.server = BackgroundServer(
+            lambda: UnmanicWebApplication([(r"/unmanic/api/v2/auth/(.*)", ApiAuthHandler)])
+        )
+        self.base_url = self.server.start()
+
+    def teardown_method(self):
+        self.server.stop()
+        destroy_test_database(self.db, MODELS)
+
+    def _cookies(self):
+        token = sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        return {sessions.COOKIE_NAME: token}
+
+    def _get(self, path, **kwargs):
+        kwargs.setdefault("timeout", 10)
+        kwargs.setdefault("allow_redirects", False)
+        return requests.get(self.base_url + path, **kwargs)
+
+    def _post(self, path, payload, **kwargs):
+        kwargs.setdefault("timeout", 10)
+        kwargs.setdefault("allow_redirects", False)
+        return requests.post(self.base_url + path, data=json.dumps(payload), **kwargs)
+
+    def test_state_reports_disabled_by_default(self):
+        response = self._get("/unmanic/api/v2/auth/state")
+        assert response.status_code == 200
+        assert response.json()["enabled"] is False
+
+    def test_configure_can_enable_auth_while_it_is_off(self):
+        response = self._post(
+            "/unmanic/api/v2/auth/configure",
+            {"enabled": True, "username": "jordan", "password": "a-good-password"},
+        )
+        assert response.status_code == 200
+        assert self.settings.get_auth_enabled() is True
+        assert credentials.verify_credential("jordan", "a-good-password") is True
+
+    def test_configure_rejects_a_short_password(self):
+        response = self._post(
+            "/unmanic/api/v2/auth/configure",
+            {"enabled": True, "username": "jordan", "password": "short"},
+        )
+        assert response.status_code == 400
+
+    def test_configure_rejects_enabling_with_no_password_at_all(self):
+        response = self._post("/unmanic/api/v2/auth/configure", {"enabled": True})
+        assert response.status_code == 400
+        assert self.settings.get_auth_enabled() is False
+
+    def test_state_never_returns_the_password_hash(self):
+        credentials.set_credential("jordan", "a-good-password")
+        self.settings.set_config_item("auth_enabled", True, save_settings=False)
+        response = self._get("/unmanic/api/v2/auth/state", cookies=self._cookies())
+        assert response.status_code == 200
+        assert "password_hash" not in response.text
+        assert "scrypt" not in response.text
+
+    def test_password_change_requires_the_current_password(self):
+        credentials.set_credential("jordan", "a-good-password")
+        self.settings.set_config_item("auth_enabled", True, save_settings=False)
+        response = self._post(
+            "/unmanic/api/v2/auth/password",
+            {"current_password": "wrong-password", "new_password": "another-good-password"},
+            cookies=self._cookies(),
+        )
+        assert response.status_code == 400
+        assert credentials.verify_credential("jordan", "a-good-password") is True
+
+    def test_password_change_revokes_other_sessions_but_keeps_the_caller_signed_in(self):
+        credentials.set_credential("jordan", "a-good-password")
+        self.settings.set_config_item("auth_enabled", True, save_settings=False)
+        sessions.create_session("10.0.0.2", "other-browser", 7, 30)
+        response = self._post(
+            "/unmanic/api/v2/auth/password",
+            {"current_password": "a-good-password", "new_password": "another-good-password"},
+            cookies=self._cookies(),
+        )
+        assert response.status_code == 200
+        assert WebAuthSessions.select().count() == 1
+        assert sessions.COOKIE_NAME in response.headers.get("Set-Cookie")
+
+    def test_sessions_can_be_listed_and_revoked(self):
+        credentials.set_credential("jordan", "a-good-password")
+        self.settings.set_config_item("auth_enabled", True, save_settings=False)
+        sessions.create_session("10.0.0.2", "other-browser", 7, 30)
+        cookies = self._cookies()
+        listed = self._get("/unmanic/api/v2/auth/sessions", cookies=cookies).json()
+        assert len(listed["sessions"]) == 2
+        response = self._post("/unmanic/api/v2/auth/sessions/revoke", {"all": True}, cookies=cookies)
+        assert response.status_code == 200
+        assert WebAuthSessions.select().count() == 0
+
+    def test_revoke_requires_an_id_or_all(self):
+        credentials.set_credential("jordan", "a-good-password")
+        self.settings.set_config_item("auth_enabled", True, save_settings=False)
+        response = self._post("/unmanic/api/v2/auth/sessions/revoke", {}, cookies=self._cookies())
+        assert response.status_code == 400
+
+    def test_endpoints_require_authentication_once_enabled(self):
+        credentials.set_credential("jordan", "a-good-password")
+        self.settings.set_config_item("auth_enabled", True, save_settings=False)
+        assert self._get("/unmanic/api/v2/auth/state").status_code == 401
+
+    def test_disabling_auth_revokes_every_session(self):
+        credentials.set_credential("jordan", "a-good-password")
+        self.settings.set_config_item("auth_enabled", True, save_settings=False)
+        cookies = self._cookies()
+        response = self._post("/unmanic/api/v2/auth/configure", {"enabled": False}, cookies=cookies)
+        assert response.status_code == 200
+        assert self.settings.get_auth_enabled() is False
+        assert WebAuthSessions.select().count() == 0

--- a/tests/integration/test_webauth_api.py
+++ b/tests/integration/test_webauth_api.py
@@ -32,6 +32,9 @@ class TestAuthApi(object):
         config.Config._instances = {}
         self.settings = config.Config(config_path=tempfile.mkdtemp(prefix="unmanic_tests_"))
         credentials.flush_verify_cache()
+        # State the starting condition rather than inheriting it: a fresh config directory
+        # now defaults to authentication enabled.
+        self.settings.set_config_item("auth_enabled", False, save_settings=False)
         self.server = BackgroundServer(
             lambda: UnmanicWebApplication([(r"/unmanic/api/v2/auth/(.*)", ApiAuthHandler)])
         )
@@ -55,7 +58,7 @@ class TestAuthApi(object):
         kwargs.setdefault("allow_redirects", False)
         return requests.post(self.base_url + path, data=json.dumps(payload), **kwargs)
 
-    def test_state_reports_disabled_by_default(self):
+    def test_state_reports_when_authentication_is_disabled(self):
         response = self._get("/unmanic/api/v2/auth/state")
         assert response.status_code == 200
         assert response.json()["enabled"] is False

--- a/tests/integration/test_webauth_enforcement.py
+++ b/tests/integration/test_webauth_enforcement.py
@@ -62,6 +62,9 @@ class WebAuthServerTestBase(object):
         config.Config._instances = {}
         self.settings = config.Config(config_path=tempfile.mkdtemp(prefix="unmanic_tests_"))
         credentials.flush_verify_cache()
+        # State the starting condition rather than inheriting it: a fresh config directory
+        # now defaults to authentication enabled.
+        self.settings.set_config_item("auth_enabled", False, save_settings=False)
         self.server = BackgroundServer(lambda: UnmanicWebApplication(list(ROUTES)))
         self.base_url = self.server.start()
 
@@ -86,7 +89,7 @@ class WebAuthServerTestBase(object):
 
 @pytest.mark.integrationtest
 class TestEnforcement(WebAuthServerTestBase):
-    def test_disabled_auth_changes_nothing(self):
+    def test_behaviour_is_unchanged_when_authentication_is_disabled(self):
         assert self.get("/unmanic/api/v2/version/read").status_code == 200
 
     def test_enabled_auth_blocks_anonymous_api_access(self):

--- a/tests/integration/test_webauth_enforcement.py
+++ b/tests/integration/test_webauth_enforcement.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import tempfile
+
+import pytest
+import requests
+import tornado.web
+import tornado.websocket
+
+from tests.support_.webauth_db import create_test_database, destroy_test_database
+from tests.support_.webauth_server import BackgroundServer, basic_header, websocket_handshake_headers
+from unmanic import config
+from unmanic.libs.uiserver import UnmanicWebApplication
+from unmanic.libs.unmodels.webauthcredentials import WebAuthCredentials
+from unmanic.libs.unmodels.webauthsessions import WebAuthSessions
+from unmanic.libs.webauth import credentials, sessions
+
+MODELS = [WebAuthCredentials, WebAuthSessions]
+
+
+class EchoHandler(tornado.web.RequestHandler):
+    def get(self, *args, **kwargs):
+        self.write("ok")
+
+    def post(self, *args, **kwargs):
+        self.write("ok")
+
+
+class EchoWebSocket(tornado.websocket.WebSocketHandler):
+    def open(self, *args, **kwargs):
+        self.write_message("ok")
+
+
+ROUTES = [
+    (r"/unmanic/websocket", EchoWebSocket),
+    (r"/unmanic/api/v1/(.*)", EchoHandler),
+    (r"/unmanic/api/v2/(.*)", EchoHandler),
+    (r"/unmanic/downloads/(.*)", EchoHandler),
+    (r"/unmanic/swagger(.*)", EchoHandler),
+    (r"/unmanic/panel/(.*)", EchoHandler),
+    (r"/unmanic/plugin_api/(.*)", EchoHandler),
+    (r"/unmanic/js/(.*)", EchoHandler),
+    (r"/unmanic/ui/(.*)", EchoHandler),
+    (r"/(.*)", EchoHandler),
+]
+
+
+class WebAuthServerTestBase(object):
+    """
+    Shared setup: an isolated database, fresh settings, and a real server on a random port.
+    """
+
+    def setup_method(self):
+        self.db = create_test_database(MODELS)
+        config.Config._instances = {}
+        self.settings = config.Config(config_path=tempfile.mkdtemp(prefix="unmanic_tests_"))
+        credentials.flush_verify_cache()
+        self.server = BackgroundServer(lambda: UnmanicWebApplication(list(ROUTES)))
+        self.base_url = self.server.start()
+
+    def teardown_method(self):
+        self.server.stop()
+        destroy_test_database(self.db, MODELS)
+
+    def get(self, path, **kwargs):
+        kwargs.setdefault("allow_redirects", False)
+        kwargs.setdefault("timeout", 10)
+        return requests.get(self.base_url + path, **kwargs)
+
+    def post(self, path, **kwargs):
+        kwargs.setdefault("allow_redirects", False)
+        kwargs.setdefault("timeout", 10)
+        return requests.post(self.base_url + path, **kwargs)
+
+    def enable_auth(self):
+        self.settings.set_config_item("auth_enabled", True, save_settings=False)
+        credentials.set_credential("jordan", "a-good-password")
+
+
+@pytest.mark.integrationtest
+class TestEnforcement(WebAuthServerTestBase):
+    def test_disabled_auth_changes_nothing(self):
+        assert self.get("/unmanic/api/v2/version/read").status_code == 200
+
+    def test_enabled_auth_blocks_anonymous_api_access(self):
+        self.enable_auth()
+        assert self.get("/unmanic/api/v2/version/read").status_code == 401
+
+    def test_no_www_authenticate_header_is_ever_sent(self):
+        self.enable_auth()
+        response = self.get("/unmanic/api/v2/version/read")
+        assert response.headers.get("WWW-Authenticate") is None
+
+    def test_browser_navigation_is_redirected_to_login(self):
+        self.enable_auth()
+        response = self.get("/unmanic/ui/dashboard/", headers={"Accept": "text/html"})
+        assert response.status_code == 302
+        assert response.headers["Location"].startswith("/unmanic/login")
+
+    def test_the_redirect_preserves_the_requested_path(self):
+        self.enable_auth()
+        response = self.get("/unmanic/ui/settings/", headers={"Accept": "text/html"})
+        assert "next=" in response.headers["Location"]
+
+    def test_basic_auth_is_accepted(self):
+        self.enable_auth()
+        response = self.get(
+            "/unmanic/api/v2/version/read",
+            headers={"Authorization": basic_header("jordan", "a-good-password")},
+        )
+        assert response.status_code == 200
+
+    def test_basic_auth_with_a_wrong_password_is_rejected(self):
+        self.enable_auth()
+        response = self.get(
+            "/unmanic/api/v2/version/read", headers={"Authorization": basic_header("jordan", "wrong-password")}
+        )
+        assert response.status_code == 401
+
+    def test_basic_auth_can_be_disabled(self):
+        self.enable_auth()
+        self.settings.set_config_item("auth_allow_basic", False, save_settings=False)
+        response = self.get(
+            "/unmanic/api/v2/version/read",
+            headers={"Authorization": basic_header("jordan", "a-good-password")},
+        )
+        assert response.status_code == 401
+
+    def test_cross_origin_post_is_rejected(self):
+        self.enable_auth()
+        response = self.post(
+            "/unmanic/api/v2/version/read",
+            data="{}",
+            headers={
+                "Authorization": basic_header("jordan", "a-good-password"),
+                "Origin": "http://evil.example.com",
+            },
+        )
+        assert response.status_code == 403
+
+    def test_same_origin_post_is_allowed(self):
+        self.enable_auth()
+        response = self.post(
+            "/unmanic/api/v2/version/read",
+            data="{}",
+            headers={
+                "Authorization": basic_header("jordan", "a-good-password"),
+                "Origin": self.base_url,
+            },
+        )
+        assert response.status_code == 200
+
+    def test_post_without_an_origin_header_is_allowed(self):
+        self.enable_auth()
+        response = self.post(
+            "/unmanic/api/v2/version/read",
+            data="{}",
+            headers={"Authorization": basic_header("jordan", "a-good-password")},
+        )
+        assert response.status_code == 200
+
+    def test_cross_site_fetch_to_the_api_is_rejected(self):
+        self.enable_auth()
+        response = self.get(
+            "/unmanic/api/v2/version/read",
+            headers={
+                "Authorization": basic_header("jordan", "a-good-password"),
+                "Sec-Fetch-Site": "cross-site",
+            },
+        )
+        assert response.status_code == 403
+
+    def test_cross_site_navigation_to_the_ui_is_still_allowed(self):
+        # The unmanic.app account flow returns cross-site to /unmanic/ui/trigger/.
+        self.enable_auth()
+        token = sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        response = self.get(
+            "/unmanic/ui/trigger/",
+            headers={"Sec-Fetch-Site": "cross-site"},
+            cookies={sessions.COOKIE_NAME: token},
+        )
+        assert response.status_code == 200
+
+    def test_setup_is_required_when_no_credential_exists(self):
+        self.settings.set_config_item("auth_enabled", True, save_settings=False)
+        response = self.get("/unmanic/ui/dashboard/", headers={"Accept": "text/html"})
+        assert response.status_code == 302
+        assert response.headers["Location"] == "/unmanic/setup"
+
+
+@pytest.mark.integrationtest
+class TestEveryRouteShapeIsCovered(WebAuthServerTestBase):
+    def test_no_route_shape_is_reachable_anonymously(self):
+        self.enable_auth()
+        paths = [
+            "/unmanic/api/v1/pending",
+            "/unmanic/api/v2/version/read",
+            "/unmanic/downloads/some-file",
+            "/unmanic/swagger",
+            "/unmanic/panel/some-plugin",
+            "/unmanic/plugin_api/some-plugin",
+            "/unmanic/js/app.js",
+            "/unmanic/ui/dashboard/",
+            "/",
+        ]
+        for path in paths:
+            response = self.get(path)
+            assert response.status_code in (401, 302), "{} was reachable anonymously ({})".format(
+                path, response.status_code
+            )
+
+    def test_every_route_shape_is_reachable_once_authenticated(self):
+        self.enable_auth()
+        token = sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        for path in ["/unmanic/api/v2/version/read", "/unmanic/ui/dashboard/", "/unmanic/js/app.js"]:
+            response = self.get(path, cookies={sessions.COOKIE_NAME: token})
+            assert response.status_code == 200, "{} was blocked when authenticated".format(path)
+
+    def test_websocket_handshake_is_rejected_without_a_session(self):
+        # Browsers do not send Authorization on a WS handshake, so the cookie is the only
+        # credential the WebSocket can ever carry. Verified against real Chrome, 2026-08-17.
+        self.enable_auth()
+        response = self.get("/unmanic/websocket", headers=websocket_handshake_headers())
+        assert response.status_code in (401, 302)
+
+    def test_websocket_handshake_is_accepted_with_a_session_cookie(self):
+        self.enable_auth()
+        token = sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        response = self.get(
+            "/unmanic/websocket",
+            headers=websocket_handshake_headers(),
+            cookies={sessions.COOKIE_NAME: token},
+        )
+        assert response.status_code == 101

--- a/tests/integration/test_webauth_login.py
+++ b/tests/integration/test_webauth_login.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import tempfile
+
+import pytest
+import requests
+import tornado.web
+
+from tests.support_.webauth_db import create_test_database, destroy_test_database
+from tests.support_.webauth_server import BackgroundServer
+from unmanic import config
+from unmanic.libs.uiserver import UnmanicWebApplication
+from unmanic.libs.unmodels.webauthcredentials import WebAuthCredentials
+from unmanic.libs.unmodels.webauthsessions import WebAuthSessions
+from unmanic.libs.webauth import credentials, sessions
+from unmanic.libs.webauth.throttle import login_throttle
+from unmanic.webserver.webauth import LoginActionHandler, LoginPageHandler, LogoutActionHandler
+
+MODELS = [WebAuthCredentials, WebAuthSessions]
+
+
+class EchoHandler(tornado.web.RequestHandler):
+    def get(self, *args, **kwargs):
+        self.write("ok")
+
+
+@pytest.mark.integrationtest
+class TestLoginFlow(object):
+    def setup_method(self):
+        self.db = create_test_database(MODELS)
+        config.Config._instances = {}
+        self.settings = config.Config(config_path=tempfile.mkdtemp(prefix="unmanic_tests_"))
+        credentials.flush_verify_cache()
+        login_throttle.record_success("login:127.0.0.1")
+        self.server = BackgroundServer(
+            lambda: UnmanicWebApplication([
+                (r"/unmanic/login", LoginPageHandler),
+                (r"/unmanic/auth/login", LoginActionHandler),
+                (r"/unmanic/auth/logout", LogoutActionHandler),
+                (r"/(.*)", EchoHandler),
+            ])
+        )
+        self.base_url = self.server.start()
+        self.settings.set_config_item("auth_enabled", True, save_settings=False)
+        credentials.set_credential("jordan", "a-good-password")
+
+    def teardown_method(self):
+        self.server.stop()
+        destroy_test_database(self.db, MODELS)
+        login_throttle.record_success("login:127.0.0.1")
+
+    def _login(self, username="jordan", password="a-good-password", next_path=None):
+        body = {"username": username, "password": password}
+        if next_path is not None:
+            body["next"] = next_path
+        return requests.post(
+            self.base_url + "/unmanic/auth/login",
+            data=body,
+            allow_redirects=False,
+            timeout=10,
+        )
+
+    def test_login_page_is_reachable_without_credentials(self):
+        response = requests.get(self.base_url + "/unmanic/login", timeout=10)
+        assert response.status_code == 200
+        assert "password" in response.text.lower()
+
+    def test_login_page_is_self_contained(self):
+        # No external assets, or the guard allowlist would need to open static paths up.
+        body = requests.get(self.base_url + "/unmanic/login", timeout=10).text
+        assert "<script src=" not in body
+        assert '<link rel="stylesheet"' not in body
+        assert "<img" not in body
+
+    def test_successful_login_sets_a_session_cookie_and_redirects(self):
+        response = self._login()
+        assert response.status_code == 302
+        assert response.headers["Location"] == "/unmanic/ui/dashboard/"
+        cookie = response.headers.get("Set-Cookie")
+        assert sessions.COOKIE_NAME in cookie
+        assert "HttpOnly" in cookie
+        assert "SameSite=Lax" in cookie
+
+    def test_secure_flag_is_absent_without_tls(self):
+        assert "Secure" not in self._login().headers.get("Set-Cookie")
+
+    def test_secure_flag_is_present_with_tls(self):
+        self.settings.set_config_item("ssl_enabled", True, save_settings=False)
+        assert "Secure" in self._login().headers.get("Set-Cookie")
+
+    def test_the_session_cookie_grants_access(self):
+        token = self._login().cookies[sessions.COOKIE_NAME]
+        response = requests.get(
+            self.base_url + "/unmanic/api/v2/version/read",
+            cookies={sessions.COOKIE_NAME: token},
+            allow_redirects=False,
+            timeout=10,
+        )
+        assert response.status_code == 200
+
+    def test_bad_credentials_do_not_set_a_cookie(self):
+        response = self._login(password="wrong-password")
+        assert response.status_code == 401
+        assert sessions.COOKIE_NAME not in (response.headers.get("Set-Cookie") or "")
+
+    def test_the_error_message_does_not_reveal_which_field_was_wrong(self):
+        wrong_password = self._login(password="wrong-password").text
+        wrong_user = self._login(username="nobody").text
+        assert wrong_password == wrong_user
+
+    def test_next_is_honoured_when_local(self):
+        response = self._login(next_path="/unmanic/ui/settings/")
+        assert response.headers["Location"] == "/unmanic/ui/settings/"
+
+    def test_next_cannot_redirect_off_site(self):
+        response = self._login(next_path="https://evil.example.com")
+        assert response.headers["Location"] == "/unmanic/ui/dashboard/"
+
+    def test_logout_revokes_the_session(self):
+        token = self._login().cookies[sessions.COOKIE_NAME]
+        response = requests.post(
+            self.base_url + "/unmanic/auth/logout",
+            cookies={sessions.COOKIE_NAME: token},
+            allow_redirects=False,
+            timeout=10,
+        )
+        assert response.status_code == 302
+        assert WebAuthSessions.select().count() == 0
+        after = requests.get(
+            self.base_url + "/unmanic/api/v2/version/read",
+            cookies={sessions.COOKIE_NAME: token},
+            allow_redirects=False,
+            timeout=10,
+        )
+        assert after.status_code == 401
+
+    def test_logout_is_not_reachable_by_get(self):
+        token = self._login().cookies[sessions.COOKIE_NAME]
+        response = requests.get(
+            self.base_url + "/unmanic/auth/logout",
+            cookies={sessions.COOKIE_NAME: token},
+            allow_redirects=False,
+            timeout=10,
+        )
+        assert response.status_code == 405
+
+    def test_repeated_failures_are_throttled(self):
+        last = None
+        for _ in range(8):
+            last = self._login(password="wrong-password")
+        assert last.status_code == 429
+        assert last.headers.get("Retry-After") is not None

--- a/tests/integration/test_webauth_login.py
+++ b/tests/integration/test_webauth_login.py
@@ -157,3 +157,25 @@ class TestLoginFlow(object):
             last = self._login(password="wrong-password")
         assert last.status_code == 429
         assert last.headers.get("Retry-After") is not None
+
+    def test_rendering_auth_pages_does_not_hijack_the_shared_template_loader_cache(self):
+        # Tornado caches template loaders in RequestHandler._template_loaders, keyed by
+        # template path and shared by every handler in the process. With no template path
+        # set, the key is derived from the calling module's directory - which for
+        # webauth.py is unmanic/webserver, the same key main.py's MainUIRequestHandler
+        # derives. Caching the auth loader under that key makes the whole frontend look
+        # for index.html inside the auth template directory.
+        import os
+
+        import tornado.web
+
+        import unmanic.webserver.main as webserver_main
+
+        requests.get(self.base_url + "/unmanic/login", timeout=10)
+
+        shared_key = os.path.dirname(os.path.abspath(webserver_main.__file__))
+        cached = tornado.web.RequestHandler._template_loaders
+        assert shared_key not in cached, (
+            "the auth template loader was cached under {!r}, which MainUIRequestHandler "
+            "also uses - this breaks the entire frontend".format(shared_key)
+        )

--- a/tests/integration/test_webauth_setup.py
+++ b/tests/integration/test_webauth_setup.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import tempfile
+
+import pytest
+import requests
+import tornado.web
+
+from tests.support_.webauth_db import create_test_database, destroy_test_database
+from tests.support_.webauth_server import BackgroundServer
+from unmanic import config
+from unmanic.libs.uiserver import UnmanicWebApplication
+from unmanic.libs.unmodels.webauthcredentials import WebAuthCredentials
+from unmanic.libs.unmodels.webauthsessions import WebAuthSessions
+from unmanic.libs.webauth import credentials, sessions
+from unmanic.libs.webauth.throttle import login_throttle
+from unmanic.webserver.webauth import SetupActionHandler, SetupPageHandler
+
+MODELS = [WebAuthCredentials, WebAuthSessions]
+
+
+class EchoHandler(tornado.web.RequestHandler):
+    def get(self, *args, **kwargs):
+        self.write("ok")
+
+
+@pytest.mark.integrationtest
+class TestSetupFlow(object):
+    def setup_method(self):
+        self.db = create_test_database(MODELS)
+        config.Config._instances = {}
+        self.settings = config.Config(config_path=tempfile.mkdtemp(prefix="unmanic_tests_"))
+        credentials.flush_verify_cache()
+        login_throttle.record_success("login:127.0.0.1")
+        self.server = BackgroundServer(
+            lambda: UnmanicWebApplication([
+                (r"/unmanic/setup", SetupPageHandler),
+                (r"/unmanic/auth/setup", SetupActionHandler),
+                (r"/(.*)", EchoHandler),
+            ])
+        )
+        self.base_url = self.server.start()
+        self.settings.set_config_item("auth_enabled", True, save_settings=False)
+
+    def teardown_method(self):
+        self.server.stop()
+        destroy_test_database(self.db, MODELS)
+        login_throttle.record_success("login:127.0.0.1")
+
+    def _submit(self, username="jordan", password="a-good-password", confirm=None):
+        body = {
+            "username": username,
+            "password": password,
+            "confirm": confirm if confirm is not None else password,
+        }
+        return requests.post(
+            self.base_url + "/unmanic/auth/setup", data=body, allow_redirects=False, timeout=10
+        )
+
+    def test_setup_page_is_served_when_no_credential_exists(self):
+        response = requests.get(self.base_url + "/unmanic/setup", timeout=10)
+        assert response.status_code == 200
+
+    def test_the_setup_page_states_it_is_not_internet_protection(self):
+        body = requests.get(self.base_url + "/unmanic/setup", timeout=10).text
+        assert "does not make Unmanic safe to" in body
+
+    def test_other_routes_redirect_to_setup(self):
+        response = requests.get(
+            self.base_url + "/unmanic/ui/dashboard/",
+            headers={"Accept": "text/html"},
+            allow_redirects=False,
+            timeout=10,
+        )
+        assert response.status_code == 302
+        assert response.headers["Location"] == "/unmanic/setup"
+
+    def test_submitting_setup_creates_the_account_and_signs_in(self):
+        response = self._submit()
+        assert response.status_code == 302
+        assert response.headers["Location"] == "/unmanic/ui/dashboard/"
+        assert credentials.credential_is_configured() is True
+        assert sessions.COOKIE_NAME in response.headers.get("Set-Cookie")
+
+    def test_mismatched_confirmation_is_rejected(self):
+        response = self._submit(confirm="something-else")
+        assert response.status_code == 400
+        assert credentials.credential_is_configured() is False
+
+    def test_short_password_is_rejected(self):
+        response = self._submit(password="short", confirm="short")
+        assert response.status_code == 400
+        assert credentials.credential_is_configured() is False
+
+    def test_setup_routes_return_404_once_a_credential_exists(self):
+        self._submit()
+        assert requests.get(self.base_url + "/unmanic/setup", timeout=10).status_code == 404
+        assert self._submit(username="someone-else").status_code == 404
+
+    def test_setup_cannot_be_used_to_replace_an_existing_credential(self):
+        self._submit()
+        self._submit(username="attacker", password="attacker-password")
+        assert credentials.get_username() == "jordan"

--- a/tests/integration/test_webauth_setup.py
+++ b/tests/integration/test_webauth_setup.py
@@ -108,3 +108,17 @@ class TestSetupFlow(object):
         self._submit()
         self._submit(username="attacker", password="attacker-password")
         assert credentials.get_username() == "jordan"
+
+    def test_setup_page_is_self_contained(self):
+        # The page carries inline JS for live validation. Inline is fine; an external file
+        # would not be, because the guard allowlist deliberately opens no static paths.
+        body = requests.get(self.base_url + "/unmanic/setup", timeout=10).text
+        assert "<script src=" not in body
+        assert '<link rel="stylesheet"' not in body
+        assert "<img" not in body
+        assert "<script>" in body, "live validation script is missing"
+
+    def test_setup_page_advertises_the_length_rule_the_server_enforces(self):
+        body = requests.get(self.base_url + "/unmanic/setup", timeout=10).text
+        assert str(credentials.MIN_PASSWORD_LENGTH) in body
+        assert str(credentials.MAX_PASSWORD_LENGTH) in body

--- a/tests/support_/webauth_db.py
+++ b/tests/support_/webauth_db.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import os
+import shutil
+import tempfile
+
+from peewee import SqliteDatabase
+
+from unmanic.libs.unmodels.lib import db
+
+_temp_dirs = []
+
+
+def create_test_database(models):
+    """
+    Create an isolated database for a test and create the given tables in it.
+
+    Deliberately a plain SqliteDatabase rather than the SqliteQueueDatabase the
+    application uses. The queue database executes statements on a worker thread holding
+    its own connection, which does not observe DDL issued from the calling thread within
+    a test - queries fail with "no such table" even though the table is on disk. The
+    models bind to a DatabaseProxy, so pointing that proxy at a plain database gives the
+    same model behaviour without the worker thread.
+
+    A temporary file is used rather than ':memory:', which is private per connection.
+
+    :param models:
+    :return:
+    """
+    temp_dir = tempfile.mkdtemp(prefix="unmanic_tests_db_")
+    _temp_dirs.append(temp_dir)
+    database = SqliteDatabase(
+        os.path.join(temp_dir, "test.db"),
+        pragmas=(("foreign_keys", 1),),
+    )
+    db.initialize(database)
+    database.connect(reuse_if_open=True)
+    database.create_tables(models)
+    return database
+
+
+def destroy_test_database(database, models):
+    """
+    Drop the given tables and remove any temporary database directories.
+
+    :param database:
+    :param models:
+    :return:
+    """
+    try:
+        database.drop_tables(models)
+    except Exception:
+        pass
+    try:
+        database.close()
+    except Exception:
+        pass
+    while _temp_dirs:
+        shutil.rmtree(_temp_dirs.pop(), ignore_errors=True)

--- a/tests/support_/webauth_server.py
+++ b/tests/support_/webauth_server.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import asyncio
+import base64
+import os
+import threading
+
+import tornado.httpserver
+import tornado.ioloop
+import tornado.netutil
+
+
+class BackgroundServer(object):
+    """
+    BackgroundServer
+
+    Runs a Tornado application on a random port in a background thread and exposes its
+    base URL, so tests can drive it over real HTTP.
+
+    tornado.testing.AsyncHTTPTestCase is deliberately not used. Its AsyncTestCase base
+    takes a methodName argument that current pytest releases do not supply, so it fails
+    at collection with "object has no attribute 'runTest'". requirements-dev.txt pins
+    only 'pytest>=7.4.3', so that breakage applies to anyone running the suite today.
+    Driving a real server over real HTTP avoids the coupling entirely and exercises the
+    same path the application actually serves.
+    """
+
+    def __init__(self, app_factory):
+        self.app_factory = app_factory
+        self.port = None
+        self.io_loop = None
+        self._server = None
+        self._thread = None
+        self._ready = threading.Event()
+        self._error = None
+
+    def start(self) -> str:
+        """
+        Start the server and return its base URL.
+
+        :return:
+        """
+
+        def run():
+            try:
+                asyncio.set_event_loop(asyncio.new_event_loop())
+                self.io_loop = tornado.ioloop.IOLoop.current()
+                sockets = tornado.netutil.bind_sockets(0, "127.0.0.1")
+                self.port = sockets[0].getsockname()[1]
+                self._server = tornado.httpserver.HTTPServer(self.app_factory())
+                self._server.add_sockets(sockets)
+            except Exception as e:  # pragma: no cover - surfaced through start()
+                self._error = e
+                self._ready.set()
+                return
+            self._ready.set()
+            self.io_loop.start()
+
+        self._thread = threading.Thread(target=run, daemon=True)
+        self._thread.start()
+        if not self._ready.wait(15):
+            raise RuntimeError("Test server did not start within 15 seconds")
+        if self._error is not None:
+            raise self._error
+        return "http://127.0.0.1:{}".format(self.port)
+
+    def stop(self) -> None:
+        """
+        Shut the server down.
+
+        :return:
+        """
+        if self.io_loop is not None:
+            self.io_loop.add_callback(self._server.stop)
+            self.io_loop.add_callback(self.io_loop.stop)
+        if self._thread is not None:
+            self._thread.join(timeout=10)
+
+
+def basic_header(username: str, password: str) -> str:
+    """
+    Build an HTTP Basic Authorization header value.
+
+    :param username:
+    :param password:
+    :return:
+    """
+    raw = "{}:{}".format(username, password).encode("utf-8")
+    return "Basic " + base64.b64encode(raw).decode("ascii")
+
+
+def websocket_handshake_headers() -> dict:
+    """
+    Build the headers a browser sends to open a WebSocket.
+
+    Used to assert on the handshake status code without pulling in a WebSocket client
+    library. An authorised handshake answers 101; a refused one answers 401 or 302.
+
+    :return:
+    """
+    return {
+        "Upgrade": "websocket",
+        "Connection": "Upgrade",
+        "Sec-WebSocket-Key": base64.b64encode(os.urandom(16)).decode("ascii"),
+        "Sec-WebSocket-Version": "13",
+    }

--- a/tests/unit/test_webauth_bootstrap.py
+++ b/tests/unit/test_webauth_bootstrap.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import os
+import tempfile
+
+import pytest
+
+from tests.support_.webauth_db import create_test_database, destroy_test_database
+from unmanic import config
+from unmanic.libs.unmodels.webauthcredentials import WebAuthCredentials
+from unmanic.libs.unmodels.webauthsessions import WebAuthSessions
+from unmanic.libs.webauth import bootstrap, credentials
+
+MODELS = [WebAuthCredentials, WebAuthSessions]
+
+
+@pytest.mark.unittest
+class TestEnvironmentBootstrap(object):
+    def setup_method(self):
+        self.db = create_test_database(MODELS)
+        credentials.flush_verify_cache()
+        config.Config._instances = {}
+        self.config_path = tempfile.mkdtemp(prefix="unmanic_tests_")
+        self.settings = config.Config(config_path=self.config_path)
+        for key in (bootstrap.ENV_USERNAME, bootstrap.ENV_PASSWORD):
+            os.environ.pop(key, None)
+
+    def teardown_method(self):
+        destroy_test_database(self.db, MODELS)
+        for key in (bootstrap.ENV_USERNAME, bootstrap.ENV_PASSWORD):
+            os.environ.pop(key, None)
+
+    def test_no_environment_variables_is_a_no_op(self):
+        bootstrap.apply_environment_credentials(self.settings)
+        assert credentials.credential_is_configured() is False
+
+    def test_environment_variables_create_the_account(self):
+        os.environ[bootstrap.ENV_USERNAME] = "jordan"
+        os.environ[bootstrap.ENV_PASSWORD] = "a-good-password"
+        bootstrap.apply_environment_credentials(self.settings)
+        assert credentials.verify_credential("jordan", "a-good-password") is True
+
+    def test_the_plaintext_password_is_never_written_to_settings_json(self):
+        os.environ[bootstrap.ENV_USERNAME] = "jordan"
+        os.environ[bootstrap.ENV_PASSWORD] = "a-good-password"
+        bootstrap.apply_environment_credentials(self.settings)
+        self.settings.set_config_item("auth_enabled", True, save_settings=True)
+        with open(os.path.join(self.config_path, "settings.json")) as handle:
+            written = handle.read()
+        assert "a-good-password" not in written
+        assert "auth_password" not in written
+
+    def test_reapplying_the_same_password_does_not_churn_the_hash(self):
+        os.environ[bootstrap.ENV_USERNAME] = "jordan"
+        os.environ[bootstrap.ENV_PASSWORD] = "a-good-password"
+        bootstrap.apply_environment_credentials(self.settings)
+        first = WebAuthCredentials.select().first().password_hash
+        bootstrap.apply_environment_credentials(self.settings)
+        assert WebAuthCredentials.select().first().password_hash == first
+
+    def test_a_changed_environment_password_replaces_the_stored_one(self):
+        os.environ[bootstrap.ENV_USERNAME] = "jordan"
+        os.environ[bootstrap.ENV_PASSWORD] = "a-good-password"
+        bootstrap.apply_environment_credentials(self.settings)
+        os.environ[bootstrap.ENV_PASSWORD] = "a-different-password"
+        bootstrap.apply_environment_credentials(self.settings)
+        assert credentials.verify_credential("jordan", "a-different-password") is True
+
+    def test_an_invalid_environment_password_does_not_crash_startup(self):
+        os.environ[bootstrap.ENV_USERNAME] = "jordan"
+        os.environ[bootstrap.ENV_PASSWORD] = "short"
+        bootstrap.apply_environment_credentials(self.settings)
+        assert credentials.credential_is_configured() is False
+
+    def test_disable_auth_turns_the_setting_off(self):
+        self.settings.set_config_item("auth_enabled", True, save_settings=False)
+        bootstrap.run_disable_auth(self.settings)
+        assert self.settings.get_auth_enabled() is False

--- a/tests/unit/test_webauth_config.py
+++ b/tests/unit/test_webauth_config.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import tempfile
+
+import pytest
+
+from unmanic import config
+
+
+@pytest.mark.unittest
+class TestWebAuthConfig(object):
+    def _settings(self):
+        config.Config._instances = {}
+        return config.Config(config_path=tempfile.mkdtemp(prefix="unmanic_tests_"))
+
+    def test_defaults_are_off_and_permissive_to_machines(self):
+        settings = self._settings()
+        assert settings.get_auth_enabled() is False
+        assert settings.get_auth_allow_basic() is True
+        assert settings.get_auth_session_idle_timeout_days() == 7
+        assert settings.get_auth_session_max_age_days() == 30
+        assert settings.get_auth_trusted_origins() == []
+
+    def test_string_values_from_env_are_coerced(self):
+        settings = self._settings()
+        settings.set_config_item("auth_enabled", "true", save_settings=False)
+        assert settings.get_auth_enabled() is True
+        settings.set_config_item("auth_enabled", "false", save_settings=False)
+        assert settings.get_auth_enabled() is False
+        settings.set_config_item("auth_session_idle_timeout_days", "3", save_settings=False)
+        assert settings.get_auth_session_idle_timeout_days() == 3
+
+    def test_a_bare_string_does_not_read_as_enabled(self):
+        # The bug this guards: "false" is a truthy Python string.
+        settings = self._settings()
+        settings.set_config_item("auth_enabled", "no", save_settings=False)
+        assert settings.get_auth_enabled() is False
+
+    def test_trusted_origins_accept_comma_separated_string(self):
+        settings = self._settings()
+        settings.set_config_item(
+            "auth_trusted_origins", "https://a.example.com, https://b.example.com", save_settings=False
+        )
+        assert settings.get_auth_trusted_origins() == ["https://a.example.com", "https://b.example.com"]
+
+    def test_invalid_numbers_fall_back_to_defaults(self):
+        settings = self._settings()
+        settings.set_config_item("auth_session_idle_timeout_days", "not-a-number", save_settings=False)
+        assert settings.get_auth_session_idle_timeout_days() == 7

--- a/tests/unit/test_webauth_config.py
+++ b/tests/unit/test_webauth_config.py
@@ -7,6 +7,8 @@ Copyright (C) Josh Sunnex
 SPDX-License-Identifier: GPL-3.0-only
 """
 
+import json
+import os
 import tempfile
 
 import pytest
@@ -20,13 +22,44 @@ class TestWebAuthConfig(object):
         config.Config._instances = {}
         return config.Config(config_path=tempfile.mkdtemp(prefix="unmanic_tests_"))
 
-    def test_defaults_are_off_and_permissive_to_machines(self):
+    def test_defaults_are_permissive_to_machines(self):
         settings = self._settings()
-        assert settings.get_auth_enabled() is False
         assert settings.get_auth_allow_basic() is True
         assert settings.get_auth_session_idle_timeout_days() == 7
         assert settings.get_auth_session_max_age_days() == 30
         assert settings.get_auth_trusted_origins() == []
+
+    def test_a_fresh_installation_requires_authentication(self):
+        # No settings.json has ever been written, so nothing can break by turning this on.
+        settings = self._settings()
+        assert settings.get_auth_enabled() is True
+
+    def test_an_existing_installation_is_left_alone(self):
+        # A settings file that predates this feature has no auth_enabled key. Enabling
+        # authentication underneath such an installation would lock the owner out of a
+        # working system and break its remote instance links, so it stays off.
+        config_path = tempfile.mkdtemp(prefix="unmanic_tests_")
+        with open(os.path.join(config_path, "settings.json"), "w") as handle:
+            json.dump({"ui_port": 8888, "library_path": "/library"}, handle)
+        config.Config._instances = {}
+        settings = config.Config(config_path=config_path)
+        assert settings.get_auth_enabled() is False
+
+    def test_an_existing_installation_that_opted_in_keeps_it_on(self):
+        config_path = tempfile.mkdtemp(prefix="unmanic_tests_")
+        with open(os.path.join(config_path, "settings.json"), "w") as handle:
+            json.dump({"auth_enabled": True}, handle)
+        config.Config._instances = {}
+        settings = config.Config(config_path=config_path)
+        assert settings.get_auth_enabled() is True
+
+    def test_an_environment_variable_overrides_the_fresh_install_default(self):
+        os.environ["auth_enabled"] = "false"
+        try:
+            settings = self._settings()
+            assert settings.get_auth_enabled() is False
+        finally:
+            os.environ.pop("auth_enabled", None)
 
     def test_string_values_from_env_are_coerced(self):
         settings = self._settings()

--- a/tests/unit/test_webauth_credential_store.py
+++ b/tests/unit/test_webauth_credential_store.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import base64
+
+import pytest
+
+from tests.support_.webauth_db import create_test_database, destroy_test_database
+from unmanic.libs.unmodels.webauthcredentials import WebAuthCredentials
+from unmanic.libs.webauth import credentials
+
+
+@pytest.mark.unittest
+class TestCredentialStore(object):
+    def setup_method(self):
+        self.db = create_test_database([WebAuthCredentials])
+        credentials.flush_verify_cache()
+
+    def teardown_method(self):
+        destroy_test_database(self.db, [WebAuthCredentials])
+
+    def test_no_credential_configured_initially(self):
+        assert credentials.credential_is_configured() is False
+        assert credentials.get_username() is None
+
+    def test_set_then_verify(self):
+        credentials.set_credential("jordan", "a-good-password")
+        assert credentials.credential_is_configured() is True
+        assert credentials.get_username() == "jordan"
+        assert credentials.verify_credential("jordan", "a-good-password") is True
+
+    def test_wrong_username_or_password_rejected(self):
+        credentials.set_credential("jordan", "a-good-password")
+        assert credentials.verify_credential("jordan", "wrong") is False
+        assert credentials.verify_credential("someone", "a-good-password") is False
+
+    def test_username_comparison_is_case_sensitive(self):
+        credentials.set_credential("jordan", "a-good-password")
+        assert credentials.verify_credential("Jordan", "a-good-password") is False
+
+    def test_setting_a_credential_replaces_rather_than_appends(self):
+        credentials.set_credential("jordan", "first-password")
+        credentials.set_credential("jordan", "second-password")
+        assert WebAuthCredentials.select().count() == 1
+        assert credentials.verify_credential("jordan", "first-password") is False
+        assert credentials.verify_credential("jordan", "second-password") is True
+
+    def test_plaintext_password_is_never_stored(self):
+        credentials.set_credential("jordan", "a-good-password")
+        row = WebAuthCredentials.select().first()
+        assert "a-good-password" not in row.password_hash
+
+    def test_password_length_is_validated(self):
+        with pytest.raises(ValueError):
+            credentials.set_credential("jordan", "short")
+        with pytest.raises(ValueError):
+            credentials.set_credential("jordan", "x" * (credentials.MAX_PASSWORD_LENGTH + 1))
+
+    def test_username_is_validated(self):
+        with pytest.raises(ValueError):
+            credentials.set_credential("", "a-good-password")
+        with pytest.raises(ValueError):
+            credentials.set_credential("   ", "a-good-password")
+
+    def test_verify_with_no_credential_configured_is_false(self):
+        assert credentials.verify_credential("jordan", "a-good-password") is False
+
+    def test_clear_credential(self):
+        credentials.set_credential("jordan", "a-good-password")
+        credentials.clear_credential()
+        assert credentials.credential_is_configured() is False
+
+
+@pytest.mark.unittest
+class TestBasicHeaderVerification(object):
+    def setup_method(self):
+        self.db = create_test_database([WebAuthCredentials])
+        credentials.flush_verify_cache()
+        credentials.set_credential("jordan", "a-good-password")
+
+    def teardown_method(self):
+        destroy_test_database(self.db, [WebAuthCredentials])
+
+    @staticmethod
+    def _header(raw):
+        return "Basic " + base64.b64encode(raw.encode("utf-8")).decode("ascii")
+
+    def test_valid_header_accepted(self):
+        assert credentials.verify_basic_header(self._header("jordan:a-good-password")) is True
+
+    def test_invalid_header_rejected(self):
+        assert credentials.verify_basic_header(self._header("jordan:wrong")) is False
+        assert credentials.verify_basic_header(self._header("nope:a-good-password")) is False
+
+    def test_malformed_headers_rejected_without_raising(self):
+        for bad in [None, "", "Basic", "Basic !!!!not-base64!!!!", "Bearer abc", self._header("no-colon")]:
+            assert credentials.verify_basic_header(bad) is False
+
+    def test_password_containing_a_colon_is_handled(self):
+        credentials.set_credential("jordan", "pass:with:colons")
+        credentials.flush_verify_cache()
+        assert credentials.verify_basic_header(self._header("jordan:pass:with:colons")) is True
+
+    def test_repeat_verification_is_served_from_cache(self):
+        header = self._header("jordan:a-good-password")
+        assert credentials.verify_basic_header(header) is True
+        calls = []
+        original = credentials.verify_password
+
+        def counting(password, encoded):
+            calls.append(password)
+            return original(password, encoded)
+
+        credentials.verify_password = counting
+        try:
+            assert credentials.verify_basic_header(header) is True
+        finally:
+            credentials.verify_password = original
+        assert calls == [], "second verification should have been served from the cache"
+
+    def test_cache_is_flushed_when_the_credential_changes(self):
+        header = self._header("jordan:a-good-password")
+        assert credentials.verify_basic_header(header) is True
+        credentials.set_credential("jordan", "a-different-password")
+        assert credentials.verify_basic_header(header) is False
+
+    def test_failures_are_not_cached(self):
+        # A rejected header must not be remembered as rejected: once the credential
+        # actually matches it, the very same header has to start working.
+        bad = self._header("jordan:wrong-password")
+        assert credentials.verify_basic_header(bad) is False
+        credentials.set_credential("jordan", "wrong-password")
+        assert credentials.verify_basic_header(bad) is True

--- a/tests/unit/test_webauth_credentials.py
+++ b/tests/unit/test_webauth_credentials.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import pytest
+
+from unmanic.libs.webauth import credentials
+
+
+@pytest.mark.unittest
+class TestPasswordHashing(object):
+    def test_hash_then_verify_round_trip(self):
+        encoded = credentials.hash_password("correct horse battery staple")
+        assert credentials.verify_password("correct horse battery staple", encoded) is True
+
+    def test_wrong_password_is_rejected(self):
+        encoded = credentials.hash_password("correct horse battery staple")
+        assert credentials.verify_password("Correct horse battery staple", encoded) is False
+        assert credentials.verify_password("", encoded) is False
+
+    def test_encoded_format_records_its_parameters(self):
+        encoded = credentials.hash_password("hunter2")
+        parts = encoded.split("$")
+        assert len(parts) == 6
+        assert parts[0] == "scrypt"
+        assert int(parts[1]) == credentials.SCRYPT_N
+        assert int(parts[2]) == credentials.SCRYPT_R
+        assert int(parts[3]) == credentials.SCRYPT_P
+
+    def test_the_plaintext_never_appears_in_the_encoded_hash(self):
+        encoded = credentials.hash_password("hunter2")
+        assert "hunter2" not in encoded
+
+    def test_salt_differs_between_hashes_of_the_same_password(self):
+        assert credentials.hash_password("hunter2") != credentials.hash_password("hunter2")
+
+    def test_malformed_hashes_are_rejected_and_do_not_raise(self):
+        for bad in ["", "not-a-hash", "scrypt$1$2$3", "scrypt$a$b$c$d$e", "bcrypt$1$2$3$4$5", None]:
+            assert credentials.verify_password("hunter2", bad) is False
+
+    def test_needs_rehash_detects_weaker_stored_parameters(self):
+        current = credentials.hash_password("hunter2")
+        assert credentials.needs_rehash(current) is False
+        weaker = current.replace("scrypt${}$".format(credentials.SCRYPT_N), "scrypt$1024$", 1)
+        assert credentials.needs_rehash(weaker) is True
+
+    def test_unicode_passwords_round_trip(self):
+        encoded = credentials.hash_password("pässwörd–✓")
+        assert credentials.verify_password("pässwörd–✓", encoded) is True

--- a/tests/unit/test_webauth_guard.py
+++ b/tests/unit/test_webauth_guard.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import pytest
+
+from unmanic.libs.webauth import guard
+
+
+@pytest.mark.unittest
+class TestOriginCheck(object):
+    def test_absent_origin_is_allowed_so_machine_clients_work(self):
+        assert guard.origin_is_allowed(None, "10.0.0.1:8888", []) is True
+        assert guard.origin_is_allowed("", "10.0.0.1:8888", []) is True
+
+    def test_matching_origin_is_allowed(self):
+        assert guard.origin_is_allowed("http://10.0.0.1:8888", "10.0.0.1:8888", []) is True
+        assert guard.origin_is_allowed("https://10.0.0.1:8888", "10.0.0.1:8888", []) is True
+
+    def test_mismatched_origin_is_rejected(self):
+        assert guard.origin_is_allowed("http://evil.example.com", "10.0.0.1:8888", []) is False
+
+    def test_a_different_port_is_a_different_origin(self):
+        assert guard.origin_is_allowed("http://10.0.0.1:9999", "10.0.0.1:8888", []) is False
+
+    def test_a_prefix_of_the_host_is_not_a_match(self):
+        assert guard.origin_is_allowed("http://10.0.0.1:8888.evil.com", "10.0.0.1:8888", []) is False
+
+    def test_trusted_origins_are_allowed(self):
+        trusted = ["https://unmanic.example.com"]
+        assert guard.origin_is_allowed("https://unmanic.example.com", "10.0.0.1:8888", trusted) is True
+        assert guard.origin_is_allowed("https://other.example.com", "10.0.0.1:8888", trusted) is False
+
+    def test_null_origin_is_rejected(self):
+        assert guard.origin_is_allowed("null", "10.0.0.1:8888", []) is False
+
+
+@pytest.mark.unittest
+class TestSafeNextPath(object):
+    def test_local_paths_are_preserved(self):
+        assert guard.safe_next_path("/unmanic/ui/settings/") == "/unmanic/ui/settings/"
+
+    def test_absolute_urls_are_rejected(self):
+        assert guard.safe_next_path("https://evil.example.com") == guard.DEFAULT_LANDING_PATH
+        assert guard.safe_next_path("http://evil.example.com") == guard.DEFAULT_LANDING_PATH
+
+    def test_protocol_relative_urls_are_rejected(self):
+        assert guard.safe_next_path("//evil.example.com") == guard.DEFAULT_LANDING_PATH
+        assert guard.safe_next_path("/\\evil.example.com") == guard.DEFAULT_LANDING_PATH
+        assert guard.safe_next_path("/\tevil") == guard.DEFAULT_LANDING_PATH
+
+    def test_empty_and_relative_values_fall_back(self):
+        assert guard.safe_next_path("") == guard.DEFAULT_LANDING_PATH
+        assert guard.safe_next_path(None) == guard.DEFAULT_LANDING_PATH
+        assert guard.safe_next_path("settings") == guard.DEFAULT_LANDING_PATH
+
+
+class FakeRequest(object):
+    def __init__(self, path="/unmanic/ui/dashboard/", method="GET", headers=None, cookies=None):
+        self.path = path
+        self.method = method
+        self.headers = headers or {}
+        self.cookies = cookies or {}
+        self.remote_ip = "10.0.0.9"
+        self.host = "10.0.0.1:8888"
+
+
+@pytest.mark.unittest
+class TestSecFetchSite(object):
+    def test_cross_site_is_blocked_on_guarded_prefixes(self):
+        for prefix in guard.CSRF_GUARDED_PREFIXES:
+            request = FakeRequest(path=prefix + "something", headers={"Sec-Fetch-Site": "cross-site"})
+            assert guard.sec_fetch_is_allowed(request) is False
+
+    def test_cross_site_is_permitted_on_ui_routes(self):
+        request = FakeRequest(path="/unmanic/ui/trigger/", headers={"Sec-Fetch-Site": "cross-site"})
+        assert guard.sec_fetch_is_allowed(request) is True
+
+    def test_absent_header_is_allowed_because_websockets_omit_it(self):
+        request = FakeRequest(path="/unmanic/api/v2/version/read")
+        assert guard.sec_fetch_is_allowed(request) is True
+
+    def test_same_origin_and_none_are_allowed(self):
+        for value in ["same-origin", "same-site", "none"]:
+            request = FakeRequest(path="/unmanic/api/v2/version/read", headers={"Sec-Fetch-Site": value})
+            assert guard.sec_fetch_is_allowed(request) is True
+
+
+@pytest.mark.unittest
+class TestWantsHtml(object):
+    def test_browser_navigation_wants_html(self):
+        request = FakeRequest(headers={"Accept": "text/html,application/xhtml+xml"})
+        assert guard.wants_html(request) is True
+
+    def test_xhr_does_not_want_html(self):
+        request = FakeRequest(headers={"Accept": "application/json"})
+        assert guard.wants_html(request) is False
+
+    def test_no_accept_header_does_not_want_html(self):
+        assert guard.wants_html(FakeRequest()) is False
+
+    def test_non_get_never_wants_html(self):
+        request = FakeRequest(method="POST", headers={"Accept": "text/html"})
+        assert guard.wants_html(request) is False

--- a/tests/unit/test_webauth_sessions.py
+++ b/tests/unit/test_webauth_sessions.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import datetime
+
+import pytest
+
+from tests.support_.webauth_db import create_test_database, destroy_test_database
+from unmanic.libs.unmodels.webauthsessions import WebAuthSessions
+from unmanic.libs.webauth import sessions
+
+
+@pytest.mark.unittest
+class TestSessionStore(object):
+    def setup_method(self):
+        self.db = create_test_database([WebAuthSessions])
+
+    def teardown_method(self):
+        destroy_test_database(self.db, [WebAuthSessions])
+
+    def test_create_returns_a_high_entropy_token(self):
+        token = sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        assert isinstance(token, str)
+        assert len(token) >= 40
+        assert sessions.create_session("10.0.0.1", "pytest", 7, 30) != token
+
+    def test_the_raw_token_is_never_stored(self):
+        token = sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        row = WebAuthSessions.select().first()
+        assert row.token_hash != token
+        assert token not in row.token_hash
+
+    def test_lookup_finds_a_live_session(self):
+        token = sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        assert sessions.lookup_session(token, 7) is not None
+
+    def test_lookup_rejects_unknown_and_malformed_tokens(self):
+        sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        for bad in [None, "", "not-a-token"]:
+            assert sessions.lookup_session(bad, 7) is None
+
+    def test_absolute_expiry_is_enforced(self):
+        token = sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        row = WebAuthSessions.select().first()
+        row.expires = datetime.datetime.now() - datetime.timedelta(seconds=1)
+        row.save()
+        assert sessions.lookup_session(token, 7) is None
+
+    def test_idle_timeout_is_enforced(self):
+        token = sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        row = WebAuthSessions.select().first()
+        row.last_used = datetime.datetime.now() - datetime.timedelta(days=8)
+        row.save()
+        assert sessions.lookup_session(token, 7) is None
+
+    def test_a_session_inside_the_idle_window_survives(self):
+        token = sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        row = WebAuthSessions.select().first()
+        row.last_used = datetime.datetime.now() - datetime.timedelta(days=6)
+        row.save()
+        assert sessions.lookup_session(token, 7) is not None
+
+    def test_expired_sessions_are_deleted_on_lookup(self):
+        token = sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        row = WebAuthSessions.select().first()
+        row.expires = datetime.datetime.now() - datetime.timedelta(seconds=1)
+        row.save()
+        sessions.lookup_session(token, 7)
+        assert WebAuthSessions.select().count() == 0
+
+    def test_revoke_single_session(self):
+        first = sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        second = sessions.create_session("10.0.0.2", "pytest", 7, 30)
+        assert sessions.revoke_session(first) is True
+        assert sessions.lookup_session(first, 7) is None
+        assert sessions.lookup_session(second, 7) is not None
+
+    def test_revoke_all_sessions(self):
+        sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        sessions.create_session("10.0.0.2", "pytest", 7, 30)
+        assert sessions.revoke_all_sessions() == 2
+        assert WebAuthSessions.select().count() == 0
+
+    def test_purge_expired_leaves_live_sessions(self):
+        live = sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        stale = sessions.create_session("10.0.0.2", "pytest", 7, 30)
+        row = WebAuthSessions.get(WebAuthSessions.token_hash == sessions.hash_token(stale))
+        row.expires = datetime.datetime.now() - datetime.timedelta(seconds=1)
+        row.save()
+        assert sessions.purge_expired() == 1
+        assert sessions.lookup_session(live, 7) is not None
+
+    def test_list_sessions_flags_the_current_one_and_leaks_no_hashes(self):
+        current = sessions.create_session("10.0.0.1", "browser-a", 7, 30)
+        sessions.create_session("10.0.0.2", "browser-b", 7, 30)
+        listed = sessions.list_sessions(current)
+        assert len(listed) == 2
+        assert sum(1 for item in listed if item["current"]) == 1
+        for item in listed:
+            assert "token_hash" not in item
+
+    def test_revoke_session_by_id(self):
+        token = sessions.create_session("10.0.0.1", "pytest", 7, 30)
+        row = WebAuthSessions.select().first()
+        assert sessions.revoke_session_by_id(row.id) is True
+        assert sessions.lookup_session(token, 7) is None
+        assert sessions.revoke_session_by_id(9999) is False

--- a/tests/unit/test_webauth_throttle.py
+++ b/tests/unit/test_webauth_throttle.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import pytest
+
+from unmanic.libs.webauth.throttle import LoginThrottle
+
+
+class FakeClock(object):
+    def __init__(self):
+        self.now = 1000.0
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+@pytest.mark.unittest
+class TestLoginThrottle(object):
+    def setup_method(self):
+        self.clock = FakeClock()
+        self.throttle = LoginThrottle(
+            max_failures=3, window_seconds=900, lockout_steps=(60, 300, 900), time_func=self.clock
+        )
+
+    def test_allows_by_default(self):
+        assert self.throttle.retry_after("10.0.0.1") == 0
+
+    def test_locks_out_after_the_failure_threshold(self):
+        for _ in range(3):
+            self.throttle.record_failure("10.0.0.1")
+        assert self.throttle.retry_after("10.0.0.1") == 60
+
+    def test_below_the_threshold_is_still_allowed(self):
+        self.throttle.record_failure("10.0.0.1")
+        self.throttle.record_failure("10.0.0.1")
+        assert self.throttle.retry_after("10.0.0.1") == 0
+
+    def test_lockout_expires(self):
+        for _ in range(3):
+            self.throttle.record_failure("10.0.0.1")
+        self.clock.advance(61)
+        assert self.throttle.retry_after("10.0.0.1") == 0
+
+    def test_lockout_escalates_on_repeat_offences(self):
+        for _ in range(3):
+            self.throttle.record_failure("10.0.0.1")
+        assert self.throttle.retry_after("10.0.0.1") == 60
+        self.clock.advance(61)
+        for _ in range(3):
+            self.throttle.record_failure("10.0.0.1")
+        assert self.throttle.retry_after("10.0.0.1") == 300
+        self.clock.advance(301)
+        for _ in range(3):
+            self.throttle.record_failure("10.0.0.1")
+        assert self.throttle.retry_after("10.0.0.1") == 900
+
+    def test_escalation_is_capped_at_the_last_step(self):
+        for _ in range(4):
+            for _ in range(3):
+                self.throttle.record_failure("10.0.0.1")
+            self.clock.advance(901)
+        for _ in range(3):
+            self.throttle.record_failure("10.0.0.1")
+        assert self.throttle.retry_after("10.0.0.1") == 900
+
+    def test_keys_are_isolated(self):
+        for _ in range(3):
+            self.throttle.record_failure("10.0.0.1")
+        assert self.throttle.retry_after("10.0.0.1") == 60
+        assert self.throttle.retry_after("10.0.0.2") == 0
+
+    def test_failures_outside_the_window_do_not_accumulate(self):
+        self.throttle.record_failure("10.0.0.1")
+        self.throttle.record_failure("10.0.0.1")
+        self.clock.advance(901)
+        self.throttle.record_failure("10.0.0.1")
+        assert self.throttle.retry_after("10.0.0.1") == 0
+
+    def test_success_clears_the_failure_record(self):
+        self.throttle.record_failure("10.0.0.1")
+        self.throttle.record_failure("10.0.0.1")
+        self.throttle.record_success("10.0.0.1")
+        self.throttle.record_failure("10.0.0.1")
+        assert self.throttle.retry_after("10.0.0.1") == 0
+
+    def test_retry_after_counts_down(self):
+        for _ in range(3):
+            self.throttle.record_failure("10.0.0.1")
+        self.clock.advance(20)
+        assert self.throttle.retry_after("10.0.0.1") == 40

--- a/unmanic/config.py
+++ b/unmanic/config.py
@@ -123,7 +123,7 @@ class Config(object, metaclass=SingletonType):
             self.set_config_item('userdata_path', os.path.join(kwargs.get('unmanic_path'), 'userdata'), save_settings=False)
 
         # Finally, re-read config from file and override all previous settings.
-        self.__import_settings_from_file(config_path)
+        self.__import_settings_from_file(config_path, first_load=True)
 
         # Overwrite current settings with given args
         if config_path:
@@ -173,10 +173,12 @@ class Config(object, metaclass=SingletonType):
             if setting in os.environ:
                 self.set_config_item(setting, os.environ.get(setting), save_settings=False)
 
-    def __import_settings_from_file(self, config_path=None):
+    def __import_settings_from_file(self, config_path=None, first_load=False):
         """
         Read configuration from the settings JSON file.
 
+        :param config_path:
+        :param first_load:
         :return:
         """
         # If config path was not passed as variable, use the default one
@@ -195,6 +197,15 @@ class Config(object, metaclass=SingletonType):
                 logger.exception("Exception in reading saved settings from file: %s", e)
             # Set data to Config class
             self.set_bulk_config_items(data, save_settings=False)
+        elif first_load and 'auth_enabled' not in os.environ:
+            # No settings file has ever been written, so this is a fresh installation rather
+            # than an upgrade. Require authentication by default so a new install is not left
+            # open on the network, and let the setup page collect the credentials.
+            #
+            # An upgrade takes the 'auth_enabled = False' default set in __init__ instead, so
+            # that an existing installation keeps working exactly as it did. An explicit
+            # 'auth_enabled' environment variable always wins over both.
+            self.auth_enabled = True
 
     def reload(self):
         """

--- a/unmanic/config.py
+++ b/unmanic/config.py
@@ -61,6 +61,13 @@ class Config(object, metaclass=SingletonType):
         self.ssl_certfilepath = None
         self.ssl_keyfilepath = None
 
+        # Web authentication settings
+        self.auth_enabled = False
+        self.auth_allow_basic = True
+        self.auth_session_idle_timeout_days = 7
+        self.auth_session_max_age_days = 30
+        self.auth_trusted_origins = []
+
         # Set default directories
         home_directory = common.get_home_dir()
         self.config_path = os.path.join(home_directory, '.unmanic', 'config')
@@ -609,3 +616,79 @@ class Config(object, metaclass=SingletonType):
         :return:
         """
         return self.ssl_keyfilepath
+
+    @staticmethod
+    def __as_bool(value, default):
+        """
+        Coerce a configuration value to a boolean.
+
+        Values arriving from environment variables are always strings.
+
+        :param value:
+        :param default:
+        :return:
+        """
+        if value is None:
+            return default
+        if isinstance(value, str):
+            return value.strip().lower() in ('true', '1', 'yes', 'on')
+        return bool(value)
+
+    @staticmethod
+    def __as_int(value, default):
+        """
+        Coerce a configuration value to an integer, falling back to a default.
+
+        :param value:
+        :param default:
+        :return:
+        """
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    def get_auth_enabled(self):
+        """
+        Get setting - auth_enabled
+
+        :return:
+        """
+        return self.__as_bool(self.auth_enabled, False)
+
+    def get_auth_allow_basic(self):
+        """
+        Get setting - auth_allow_basic
+
+        :return:
+        """
+        return self.__as_bool(self.auth_allow_basic, True)
+
+    def get_auth_session_idle_timeout_days(self):
+        """
+        Get setting - auth_session_idle_timeout_days
+
+        :return:
+        """
+        return self.__as_int(self.auth_session_idle_timeout_days, 7)
+
+    def get_auth_session_max_age_days(self):
+        """
+        Get setting - auth_session_max_age_days
+
+        :return:
+        """
+        return self.__as_int(self.auth_session_max_age_days, 30)
+
+    def get_auth_trusted_origins(self):
+        """
+        Get setting - auth_trusted_origins
+
+        :return:
+        """
+        value = self.auth_trusted_origins
+        if isinstance(value, str):
+            value = value.split(',')
+        if not value:
+            return []
+        return [str(origin).strip() for origin in value if str(origin).strip()]

--- a/unmanic/libs/uiserver.py
+++ b/unmanic/libs/uiserver.py
@@ -228,6 +228,19 @@ class UIServer(threading.Thread):
                 self._log("SSL enabled but certificate/key files not provided", level="error")
                 raise SystemExit
 
+        # Warn loudly if authentication is enabled but not yet configured
+        if self.config.get_auth_enabled():
+            from unmanic.libs.webauth import credentials as webauth_credentials
+
+            if not webauth_credentials.credential_is_configured():
+                self._log(
+                    "Authentication is enabled but no credentials are configured. "
+                    "Open http://<this-host>:{}/unmanic/setup to set them, or run "
+                    "'unmanic --set-password'. Until that is done, anyone who can reach this "
+                    "installation can claim it.".format(self.config.get_ui_port()),
+                    level="warning",
+                )
+
         # Web Server
         self.server = tornado.httpserver.HTTPServer(
             self.app,
@@ -258,11 +271,19 @@ class UIServer(threading.Thread):
         ], **tornado_settings)
 
         # Add authentication routes
-        from unmanic.webserver.webauth import LoginActionHandler, LoginPageHandler, LogoutActionHandler
+        from unmanic.webserver.webauth import (
+            LoginActionHandler,
+            LoginPageHandler,
+            LogoutActionHandler,
+            SetupActionHandler,
+            SetupPageHandler,
+        )
         app.add_handlers(r'.*', [
             (r"/unmanic/login", LoginPageHandler),
             (r"/unmanic/auth/login", LoginActionHandler),
             (r"/unmanic/auth/logout", LogoutActionHandler),
+            (r"/unmanic/setup", SetupPageHandler),
+            (r"/unmanic/auth/setup", SetupActionHandler),
         ])
 
         # Add API routes

--- a/unmanic/libs/uiserver.py
+++ b/unmanic/libs/uiserver.py
@@ -89,6 +89,28 @@ class UnmanicRunningTreads(object, metaclass=SingletonType):
         return self._unmanic_threads.get(name)
 
 
+class UnmanicWebApplication(tornado.web.Application):
+    """
+    UnmanicWebApplication
+
+    Applies the authentication guard to every request before routing it.
+
+    Doing this at the router rather than per handler means every route is covered by
+    construction - the REST API, the frontend, static assets, the WebSocket handshake,
+    the Swagger UI and dynamically registered plugin handlers alike. A new endpoint
+    cannot be added without authentication by forgetting a decorator.
+    """
+
+    def find_handler(self, request, **kwargs):
+        from unmanic.libs.webauth import guard
+        from unmanic.webserver.webauth import AuthFailureHandler
+
+        decision = guard.authorise(request)
+        if decision.allowed:
+            return super(UnmanicWebApplication, self).find_handler(request, **kwargs)
+        return self.get_handler_delegate(request, AuthFailureHandler, target_kwargs={"decision": decision})
+
+
 class UIServer(threading.Thread):
     config = None
     started = False
@@ -227,7 +249,7 @@ class UIServer(threading.Thread):
     def make_web_app(self):
         # Start with web application routes
         from unmanic.webserver.websocket import UnmanicWebsocketHandler
-        app = tornado.web.Application([
+        app = UnmanicWebApplication([
             (r"/unmanic/websocket", UnmanicWebsocketHandler),
             (r"/unmanic/downloads/(.*)", DownloadsHandler),
             (r"/(.*)", tornado.web.RedirectHandler, dict(

--- a/unmanic/libs/uiserver.py
+++ b/unmanic/libs/uiserver.py
@@ -257,6 +257,14 @@ class UIServer(threading.Thread):
             )),
         ], **tornado_settings)
 
+        # Add authentication routes
+        from unmanic.webserver.webauth import LoginActionHandler, LoginPageHandler, LogoutActionHandler
+        app.add_handlers(r'.*', [
+            (r"/unmanic/login", LoginPageHandler),
+            (r"/unmanic/auth/login", LoginActionHandler),
+            (r"/unmanic/auth/logout", LogoutActionHandler),
+        ])
+
         # Add API routes
         from unmanic.webserver.api_request_router import APIRequestRouter
         app.add_handlers(r'.*', [

--- a/unmanic/libs/unmodels/__init__.py
+++ b/unmanic/libs/unmodels/__init__.py
@@ -46,6 +46,7 @@ from .tags import Tags
 from .taskmetadata import TaskMetadata
 from .tasks import Tasks
 from .workergroups import WorkerGroupTags, WorkerGroups
+from .webauthcredentials import WebAuthCredentials
 from .workerschedules import WorkerSchedules
 
 __author__ = 'Josh.5 (jsunnex@gmail.com)'

--- a/unmanic/libs/unmodels/__init__.py
+++ b/unmanic/libs/unmodels/__init__.py
@@ -47,6 +47,7 @@ from .taskmetadata import TaskMetadata
 from .tasks import Tasks
 from .workergroups import WorkerGroupTags, WorkerGroups
 from .webauthcredentials import WebAuthCredentials
+from .webauthsessions import WebAuthSessions
 from .workerschedules import WorkerSchedules
 
 __author__ = 'Josh.5 (jsunnex@gmail.com)'

--- a/unmanic/libs/unmodels/webauthcredentials.py
+++ b/unmanic/libs/unmodels/webauthcredentials.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import datetime
+
+from peewee import DateTimeField, TextField
+
+from unmanic.libs.unmodels.lib import BaseModel
+
+
+class WebAuthCredentials(BaseModel):
+    """
+    WebAuthCredentials
+
+    The local web UI account. At most one row exists.
+
+    This is unrelated to unmanic.libs.session, which holds the unmanic.app
+    supporter account used to unlock features.
+    """
+
+    username = TextField(null=False, unique=True)
+    password_hash = TextField(null=False)
+    created = DateTimeField(null=False, default=datetime.datetime.now)
+    updated = DateTimeField(null=False, default=datetime.datetime.now)

--- a/unmanic/libs/unmodels/webauthsessions.py
+++ b/unmanic/libs/unmodels/webauthsessions.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import datetime
+
+from peewee import CharField, DateTimeField, TextField
+
+from unmanic.libs.unmodels.lib import BaseModel
+
+
+class WebAuthSessions(BaseModel):
+    """
+    WebAuthSessions
+
+    Live browser sessions for the local web account.
+
+    Only the SHA-256 of each session token is stored, so a leaked database yields
+    nothing that can be replayed as a session.
+    """
+
+    token_hash = CharField(null=False, unique=True, index=True, max_length=64)
+    created = DateTimeField(null=False, default=datetime.datetime.now)
+    last_used = DateTimeField(null=False, default=datetime.datetime.now)
+    expires = DateTimeField(null=False, default=datetime.datetime.now)
+    remote_addr = TextField(null=True)
+    user_agent = TextField(null=True)

--- a/unmanic/libs/webauth/__init__.py
+++ b/unmanic/libs/webauth/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""

--- a/unmanic/libs/webauth/bootstrap.py
+++ b/unmanic/libs/webauth/bootstrap.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import getpass
+import os
+
+from unmanic.libs.logs import UnmanicLogging
+from unmanic.libs.webauth import credentials, sessions
+
+logger = UnmanicLogging.get_logger(name="WebAuthBootstrap")
+
+# Read straight from the environment rather than through Config, so a plaintext password
+# is never held on the config object and can never be written out to settings.json.
+ENV_USERNAME = "auth_username"
+ENV_PASSWORD = "auth_password"
+
+
+def apply_environment_credentials(settings) -> None:
+    """
+    Configure the local web account from environment variables, if they are set.
+
+    :param settings:
+    :return:
+    """
+    username = os.environ.get(ENV_USERNAME)
+    password = os.environ.get(ENV_PASSWORD)
+    if not username or not password:
+        return
+
+    if credentials.verify_credential(username, password):
+        # Already configured with exactly these credentials; leave the stored hash alone
+        # rather than rehashing and invalidating every session on each restart.
+        return
+
+    try:
+        credentials.set_credential(username, password)
+    except ValueError as e:
+        logger.error("Ignoring web authentication credentials from the environment: %s", str(e))
+        return
+
+    sessions.revoke_all_sessions()
+    logger.warning(
+        "Configured web authentication credentials from environment variables. Note that these "
+        "remain visible to anyone able to run 'docker inspect' on this container."
+    )
+
+
+def run_set_password(settings) -> int:
+    """
+    Interactively set the local web account credentials and enable authentication.
+
+    :param settings:
+    :return:
+    """
+    print("Configure the Unmanic web UI sign in.")
+    print("These credentials control access to this installation only.")
+    print("")
+
+    current = credentials.get_username()
+    prompt = "Username [{}]: ".format(current) if current else "Username: "
+    username = input(prompt).strip() or (current or "")
+    if not username:
+        print("A username is required.")
+        return 1
+
+    password = getpass.getpass("Password: ")
+    confirm = getpass.getpass("Confirm password: ")
+    if password != confirm:
+        print("The passwords entered did not match.")
+        return 1
+
+    try:
+        credentials.set_credential(username, password)
+    except ValueError as e:
+        print(str(e))
+        return 1
+
+    revoked = sessions.revoke_all_sessions()
+    settings.set_config_item("auth_enabled", True, save_settings=True)
+    print("")
+    print("Authentication is now enabled for user '{}'.".format(username))
+    if revoked:
+        print("Signed out {} existing browser session(s).".format(revoked))
+    print("Restart Unmanic for the change to take effect.")
+    return 0
+
+
+def run_disable_auth(settings) -> int:
+    """
+    Disable authentication. This is the documented lockout recovery path.
+
+    :param settings:
+    :return:
+    """
+    sessions.revoke_all_sessions()
+    settings.set_config_item("auth_enabled", False, save_settings=True)
+    print("Authentication is now disabled. Restart Unmanic for the change to take effect.")
+    return 0

--- a/unmanic/libs/webauth/credentials.py
+++ b/unmanic/libs/webauth/credentials.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import base64
+import hashlib
+import hmac
+import secrets
+from typing import Optional
+
+# scrypt work factors. Stored inside each hash so they can be raised later without a migration.
+SCRYPT_N = 2 ** 15
+SCRYPT_R = 8
+SCRYPT_P = 1
+SALT_BYTES = 32
+KEY_BYTES = 32
+HASH_SCHEME = "scrypt"
+
+# OpenSSL applies a memory ceiling that defaults to 32 MiB, which n=2**15, r=8 exceeds.
+# It must be supplied explicitly or hashlib.scrypt raises ValueError on every call.
+_MAXMEM_HEADROOM = 2
+
+
+def _scrypt(password: str, salt: bytes, n: int, r: int, p: int) -> bytes:
+    """
+    Derive a key from a password using scrypt.
+
+    :param password:
+    :param salt:
+    :param n:
+    :param r:
+    :param p:
+    :return:
+    """
+    return hashlib.scrypt(
+        password.encode("utf-8"),
+        salt=salt,
+        n=n,
+        r=r,
+        p=p,
+        dklen=KEY_BYTES,
+        maxmem=128 * n * r * _MAXMEM_HEADROOM,
+    )
+
+
+def hash_password(password: str) -> str:
+    """
+    Hash a plaintext password for storage.
+
+    :param password:
+    :return:
+    """
+    salt = secrets.token_bytes(SALT_BYTES)
+    derived = _scrypt(password, salt, SCRYPT_N, SCRYPT_R, SCRYPT_P)
+    return "{}${}${}${}${}${}".format(
+        HASH_SCHEME,
+        SCRYPT_N,
+        SCRYPT_R,
+        SCRYPT_P,
+        base64.b64encode(salt).decode("ascii"),
+        base64.b64encode(derived).decode("ascii"),
+    )
+
+
+def _decode(encoded: Optional[str]):
+    """
+    Split a stored hash into its parts, or return None if it is not usable.
+
+    :param encoded:
+    :return:
+    """
+    if not encoded or not isinstance(encoded, str):
+        return None
+    parts = encoded.split("$")
+    if len(parts) != 6 or parts[0] != HASH_SCHEME:
+        return None
+    try:
+        n, r, p = int(parts[1]), int(parts[2]), int(parts[3])
+        salt = base64.b64decode(parts[4], validate=True)
+        derived = base64.b64decode(parts[5], validate=True)
+    except (ValueError, TypeError):
+        return None
+    if n < 2 or r < 1 or p < 1 or not salt or not derived:
+        return None
+    return n, r, p, salt, derived
+
+
+def verify_password(password: str, encoded: Optional[str]) -> bool:
+    """
+    Verify a plaintext password against a stored hash.
+
+    Returns False rather than raising for any malformed or unsupported hash.
+
+    :param password:
+    :param encoded:
+    :return:
+    """
+    decoded = _decode(encoded)
+    if decoded is None or password is None:
+        return False
+    n, r, p, salt, expected = decoded
+    try:
+        candidate = _scrypt(password, salt, n, r, p)
+    except (ValueError, MemoryError):
+        return False
+    return hmac.compare_digest(candidate, expected)
+
+
+def needs_rehash(encoded: Optional[str]) -> bool:
+    """
+    Return True if a stored hash uses weaker parameters than the current defaults.
+
+    :param encoded:
+    :return:
+    """
+    decoded = _decode(encoded)
+    if decoded is None:
+        return True
+    n, r, p, _salt, _derived = decoded
+    return n < SCRYPT_N or r < SCRYPT_R or p < SCRYPT_P

--- a/unmanic/libs/webauth/credentials.py
+++ b/unmanic/libs/webauth/credentials.py
@@ -8,9 +8,11 @@ SPDX-License-Identifier: GPL-3.0-only
 """
 
 import base64
+import datetime
 import hashlib
 import hmac
 import secrets
+import time
 from typing import Optional
 
 # scrypt work factors. Stored inside each hash so they can be raised later without a migration.
@@ -123,3 +125,162 @@ def needs_rehash(encoded: Optional[str]) -> bool:
         return True
     n, r, p, _salt, _derived = decoded
     return n < SCRYPT_N or r < SCRYPT_R or p < SCRYPT_P
+
+
+MIN_PASSWORD_LENGTH = 8
+MAX_PASSWORD_LENGTH = 128
+
+# Verified Authorization headers, keyed by a keyed digest so the raw header is never held.
+# Only successful verifications are cached, so it cannot be filled by an attacker.
+_VERIFY_CACHE_TTL_SECONDS = 300
+_verify_cache = {}
+_process_secret = secrets.token_bytes(32)
+
+
+def flush_verify_cache() -> None:
+    """
+    Drop every cached Basic verification. Called whenever credentials change.
+
+    :return:
+    """
+    global _process_secret
+    _verify_cache.clear()
+    _process_secret = secrets.token_bytes(32)
+
+
+def credential_is_configured() -> bool:
+    """
+    Return True if a local web account exists.
+
+    :return:
+    """
+    from unmanic.libs.unmodels.webauthcredentials import WebAuthCredentials
+
+    return WebAuthCredentials.select().count() > 0
+
+
+def get_username() -> Optional[str]:
+    """
+    Return the configured username, or None.
+
+    :return:
+    """
+    from unmanic.libs.unmodels.webauthcredentials import WebAuthCredentials
+
+    row = WebAuthCredentials.select().first()
+    return row.username if row else None
+
+
+def set_credential(username: str, password: str) -> None:
+    """
+    Create or replace the local web account.
+
+    :param username:
+    :param password:
+    :return:
+    """
+    from unmanic.libs.unmodels.webauthcredentials import WebAuthCredentials
+
+    if not username or not str(username).strip():
+        raise ValueError("A username is required")
+    if password is None or len(password) < MIN_PASSWORD_LENGTH:
+        raise ValueError("Password must be at least {} characters".format(MIN_PASSWORD_LENGTH))
+    if len(password) > MAX_PASSWORD_LENGTH:
+        raise ValueError("Password must be no more than {} characters".format(MAX_PASSWORD_LENGTH))
+
+    username = str(username).strip()
+    encoded = hash_password(password)
+    WebAuthCredentials.delete().execute()
+    WebAuthCredentials.create(
+        username=username,
+        password_hash=encoded,
+        created=datetime.datetime.now(),
+        updated=datetime.datetime.now(),
+    )
+    flush_verify_cache()
+
+
+def clear_credential() -> None:
+    """
+    Remove the local web account.
+
+    :return:
+    """
+    from unmanic.libs.unmodels.webauthcredentials import WebAuthCredentials
+
+    WebAuthCredentials.delete().execute()
+    flush_verify_cache()
+
+
+def verify_credential(username: str, password: str) -> bool:
+    """
+    Verify a username and password against the stored account.
+
+    :param username:
+    :param password:
+    :return:
+    """
+    from unmanic.libs.unmodels.webauthcredentials import WebAuthCredentials
+
+    row = WebAuthCredentials.select().first()
+    if row is None or username is None or password is None:
+        return False
+    username_matches = hmac.compare_digest(str(username).encode("utf-8"), str(row.username).encode("utf-8"))
+    password_matches = verify_password(password, row.password_hash)
+    # Both are evaluated unconditionally so the response time does not reveal which half failed.
+    if not (username_matches and password_matches):
+        return False
+    if needs_rehash(row.password_hash):
+        row.password_hash = hash_password(password)
+        row.save()
+        flush_verify_cache()
+    return True
+
+
+def _cache_key(header: str) -> str:
+    """
+    Derive a cache key from an Authorization header without retaining the header.
+
+    :param header:
+    :return:
+    """
+    return hmac.new(_process_secret, header.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def verify_basic_header(header: Optional[str]) -> bool:
+    """
+    Verify an HTTP Basic Authorization header, caching successful results.
+
+    Running scrypt on every request would be both a latency cost and an unauthenticated
+    CPU exhaustion vector, so a verified header is remembered for a short window.
+
+    :param header:
+    :return:
+    """
+    if not header or not isinstance(header, str):
+        return False
+    if not header.startswith("Basic "):
+        return False
+
+    key = _cache_key(header)
+    expires = _verify_cache.get(key)
+    now = time.monotonic()
+    if expires is not None:
+        if expires > now:
+            return True
+        _verify_cache.pop(key, None)
+
+    try:
+        raw = base64.b64decode(header[6:].strip(), validate=True).decode("utf-8")
+    except (ValueError, TypeError, UnicodeDecodeError):
+        return False
+    if ":" not in raw:
+        return False
+    username, password = raw.split(":", 1)
+
+    if not verify_credential(username, password):
+        return False
+
+    # Re-derive the key: verify_credential may have rotated the process secret via a rehash.
+    _verify_cache[_cache_key(header)] = now + _VERIFY_CACHE_TTL_SECONDS
+    return True

--- a/unmanic/libs/webauth/guard.py
+++ b/unmanic/libs/webauth/guard.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+from typing import List, Optional
+from urllib.parse import quote, urlsplit
+
+from unmanic import config
+from unmanic.libs.webauth import credentials, sessions
+
+DEFAULT_LANDING_PATH = "/unmanic/ui/dashboard/"
+LOGIN_PATH = "/unmanic/login"
+SETUP_PATH = "/unmanic/setup"
+
+PUBLIC_PATHS = frozenset({LOGIN_PATH, "/unmanic/auth/login"})
+SETUP_PATHS = frozenset({SETUP_PATH, "/unmanic/auth/setup"})
+
+UNSAFE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+# Prefixes a cross-site browser context has no legitimate reason to reach.
+# UI routes are deliberately excluded so the unmanic.app account flow, which returns
+# cross-site to /unmanic/ui/trigger/, keeps working.
+CSRF_GUARDED_PREFIXES = ("/unmanic/api/", "/unmanic/plugin_api/", "/unmanic/panel/")
+
+
+class AuthDecision(object):
+    """
+    AuthDecision
+
+    The outcome of an authorisation check for a single request.
+    """
+
+    def __init__(
+        self,
+        allowed: bool,
+        status: int = 401,
+        redirect_to: Optional[str] = None,
+        reason: str = "",
+        retry_after: int = 0,
+    ):
+        self.allowed = allowed
+        self.status = status
+        self.redirect_to = redirect_to
+        self.reason = reason
+        self.retry_after = retry_after
+
+
+ALLOWED = AuthDecision(True)
+
+
+def origin_is_allowed(origin: Optional[str], host: Optional[str], trusted_origins: List[str]) -> bool:
+    """
+    Return True if a request's Origin is acceptable.
+
+    An absent Origin is allowed: browsers always send it on unsafe methods, while curl
+    and instance-to-instance calls never do.
+
+    :param origin:
+    :param host:
+    :param trusted_origins:
+    :return:
+    """
+    if not origin:
+        return True
+    if origin in (trusted_origins or []):
+        return True
+    if origin == "null":
+        return False
+    parsed = urlsplit(origin)
+    if not parsed.netloc:
+        return False
+    return parsed.netloc == host
+
+
+def sec_fetch_is_allowed(request) -> bool:
+    """
+    Reject cross-site browser requests to machine-callable routes.
+
+    An absent header allows the request. This matters: browsers do not send
+    Sec-Fetch-Site on WebSocket handshakes, so requiring it would break the WebSocket.
+
+    :param request:
+    :return:
+    """
+    if request.headers.get("Sec-Fetch-Site") != "cross-site":
+        return True
+    return not str(request.path).startswith(CSRF_GUARDED_PREFIXES)
+
+
+def wants_html(request) -> bool:
+    """
+    Return True if this looks like a browser navigation that should be redirected to the
+    login page rather than given a JSON 401.
+
+    :param request:
+    :return:
+    """
+    if request.method not in ("GET", "HEAD"):
+        return False
+    return "text/html" in (request.headers.get("Accept") or "")
+
+
+def safe_next_path(value: Optional[str]) -> str:
+    """
+    Return a local redirect target, or the dashboard if the value is not a safe local path.
+
+    Blocks absolute URLs, protocol-relative URLs, and backslash or control-character tricks.
+
+    :param value:
+    :return:
+    """
+    if not value or not isinstance(value, str):
+        return DEFAULT_LANDING_PATH
+    if not value.startswith("/"):
+        return DEFAULT_LANDING_PATH
+    if value.startswith("//"):
+        return DEFAULT_LANDING_PATH
+    if any(char in value for char in ("\\", "\r", "\n", "\t")):
+        return DEFAULT_LANDING_PATH
+    return value
+
+
+def setup_required() -> bool:
+    """
+    Return True when authentication is on but no account exists yet.
+
+    :return:
+    """
+    return not credentials.credential_is_configured()
+
+
+def session_from_request(request):
+    """
+    Return the live session for a request's cookie, or None.
+
+    :param request:
+    :return:
+    """
+    settings = config.Config()
+    cookie = request.cookies.get(sessions.COOKIE_NAME)
+    if cookie is None:
+        return None
+    token = getattr(cookie, "value", None)
+    if not token:
+        return None
+    return sessions.lookup_session(token, settings.get_auth_session_idle_timeout_days())
+
+
+def authorise(request) -> AuthDecision:
+    """
+    Decide whether a request may proceed.
+
+    :param request:
+    :return:
+    """
+    settings = config.Config()
+
+    if not settings.get_auth_enabled():
+        return ALLOWED
+
+    path = str(request.path)
+
+    # CSRF layer 2: origin verification on state-changing requests. Placed above the setup
+    # and public branches so it also covers the login and setup POSTs, which are the only
+    # unauthenticated writes in the application.
+    if request.method in UNSAFE_METHODS:
+        if not origin_is_allowed(request.headers.get("Origin"), request.host, settings.get_auth_trusted_origins()):
+            return AuthDecision(False, status=403, reason="Cross-origin request rejected")
+
+    # CSRF layer 3: cross-site browser requests to machine-callable routes.
+    if not sec_fetch_is_allowed(request):
+        return AuthDecision(False, status=403, reason="Cross-site request rejected")
+
+    if setup_required():
+        if path in SETUP_PATHS:
+            return ALLOWED
+        if wants_html(request):
+            return AuthDecision(False, status=302, redirect_to=SETUP_PATH, reason="Setup required")
+        return AuthDecision(False, status=401, reason="Setup required")
+
+    if path in SETUP_PATHS:
+        # Setup is complete; do not advertise that these routes ever existed.
+        return AuthDecision(False, status=404, reason="Not found")
+
+    if path in PUBLIC_PATHS:
+        return ALLOWED
+
+    if session_from_request(request) is not None:
+        return ALLOWED
+
+    if settings.get_auth_allow_basic() and credentials.verify_basic_header(request.headers.get("Authorization")):
+        return ALLOWED
+
+    if wants_html(request):
+        target = "{}?next={}".format(LOGIN_PATH, quote(safe_next_path(path), safe=""))
+        return AuthDecision(False, status=302, redirect_to=target, reason="Authentication required")
+    return AuthDecision(False, status=401, reason="Authentication required")

--- a/unmanic/libs/webauth/sessions.py
+++ b/unmanic/libs/webauth/sessions.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import datetime
+import hashlib
+import secrets
+from typing import Any, Dict, List, Optional
+
+COOKIE_NAME = "unmanic_session"
+TOKEN_BYTES = 32
+
+# last_used is only rewritten when it is at least this stale, to avoid a database
+# write on every single request.
+TOUCH_INTERVAL_SECONDS = 60
+
+
+def hash_token(token: str) -> str:
+    """
+    Hash a session token for storage and lookup.
+
+    :param token:
+    :return:
+    """
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def create_session(
+    remote_addr: Optional[str],
+    user_agent: Optional[str],
+    idle_timeout_days: int,
+    max_age_days: int,
+) -> str:
+    """
+    Create a new session and return its token.
+
+    The token is returned once and never stored; only its hash is persisted.
+
+    :param remote_addr:
+    :param user_agent:
+    :param idle_timeout_days:
+    :param max_age_days:
+    :return:
+    """
+    from unmanic.libs.unmodels.webauthsessions import WebAuthSessions
+
+    token = secrets.token_urlsafe(TOKEN_BYTES)
+    now = datetime.datetime.now()
+    WebAuthSessions.create(
+        token_hash=hash_token(token),
+        created=now,
+        last_used=now,
+        expires=now + datetime.timedelta(days=int(max_age_days)),
+        remote_addr=remote_addr,
+        user_agent=(user_agent or "")[:512],
+    )
+    return token
+
+
+def lookup_session(token: Optional[str], idle_timeout_days: int):
+    """
+    Return the live session matching a token, or None.
+
+    Expired sessions are deleted as they are encountered.
+
+    :param token:
+    :param idle_timeout_days:
+    :return:
+    """
+    from unmanic.libs.unmodels.webauthsessions import WebAuthSessions
+
+    if not token or not isinstance(token, str):
+        return None
+    row = WebAuthSessions.get_or_none(WebAuthSessions.token_hash == hash_token(token))
+    if row is None:
+        return None
+
+    now = datetime.datetime.now()
+    idle_cutoff = now - datetime.timedelta(days=int(idle_timeout_days))
+    if row.expires <= now or row.last_used <= idle_cutoff:
+        row.delete_instance()
+        return None
+
+    if (now - row.last_used).total_seconds() >= TOUCH_INTERVAL_SECONDS:
+        row.last_used = now
+        row.save()
+    return row
+
+
+def revoke_session(token: Optional[str]) -> bool:
+    """
+    Delete the session matching a token.
+
+    :param token:
+    :return:
+    """
+    from unmanic.libs.unmodels.webauthsessions import WebAuthSessions
+
+    if not token or not isinstance(token, str):
+        return False
+    deleted = WebAuthSessions.delete().where(WebAuthSessions.token_hash == hash_token(token)).execute()
+    return deleted > 0
+
+
+def revoke_session_by_id(session_id: int) -> bool:
+    """
+    Delete a session by its row id.
+
+    :param session_id:
+    :return:
+    """
+    from unmanic.libs.unmodels.webauthsessions import WebAuthSessions
+
+    deleted = WebAuthSessions.delete().where(WebAuthSessions.id == session_id).execute()
+    return deleted > 0
+
+
+def revoke_all_sessions() -> int:
+    """
+    Delete every session.
+
+    :return:
+    """
+    from unmanic.libs.unmodels.webauthsessions import WebAuthSessions
+
+    return WebAuthSessions.delete().execute()
+
+
+def purge_expired() -> int:
+    """
+    Delete every session past its absolute expiry.
+
+    :return:
+    """
+    from unmanic.libs.unmodels.webauthsessions import WebAuthSessions
+
+    return WebAuthSessions.delete().where(WebAuthSessions.expires <= datetime.datetime.now()).execute()
+
+
+def list_sessions(current_token: Optional[str]) -> List[Dict[str, Any]]:
+    """
+    List live sessions for display. Never returns token hashes.
+
+    :param current_token:
+    :return:
+    """
+    from unmanic.libs.unmodels.webauthsessions import WebAuthSessions
+
+    current_hash = hash_token(current_token) if current_token else None
+    results = []
+    for row in WebAuthSessions.select().order_by(WebAuthSessions.last_used.desc()):
+        results.append(
+            {
+                "id": row.id,
+                "created": str(row.created),
+                "last_used": str(row.last_used),
+                "expires": str(row.expires),
+                "remote_addr": row.remote_addr,
+                "user_agent": row.user_agent,
+                "current": bool(current_hash and row.token_hash == current_hash),
+            }
+        )
+    return results

--- a/unmanic/libs/webauth/throttle.py
+++ b/unmanic/libs/webauth/throttle.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import math
+import threading
+import time
+from typing import Callable, Dict, Sequence
+
+
+class LoginThrottle(object):
+    """
+    LoginThrottle
+
+    In-memory, escalating lockout for failed authentication attempts.
+
+    No artificial delay is applied to a rejected request; a delay would itself be a
+    resource exhaustion vector. Requests are refused outright instead.
+    """
+
+    def __init__(
+        self,
+        max_failures: int = 5,
+        window_seconds: int = 900,
+        lockout_steps: Sequence[int] = (60, 300, 900),
+        time_func: Callable[[], float] = time.monotonic,
+    ):
+        self.max_failures = max_failures
+        self.window_seconds = window_seconds
+        self.lockout_steps = tuple(lockout_steps)
+        self.time_func = time_func
+        self._lock = threading.Lock()
+        self._state = {}  # type: Dict[str, Dict[str, float]]
+
+    def _entry(self, key: str) -> Dict[str, float]:
+        return self._state.setdefault(
+            key, {"failures": 0, "first_failure": 0.0, "locked_until": 0.0, "offences": 0}
+        )
+
+    def retry_after(self, key: str) -> int:
+        """
+        Return the number of seconds until this key may try again. 0 means allowed.
+
+        :param key:
+        :return:
+        """
+        with self._lock:
+            entry = self._state.get(key)
+            if entry is None:
+                return 0
+            remaining = entry["locked_until"] - self.time_func()
+            if remaining <= 0:
+                return 0
+            return int(math.ceil(remaining))
+
+    def record_failure(self, key: str) -> None:
+        """
+        Record a failed attempt, locking the key out once the threshold is reached.
+
+        :param key:
+        :return:
+        """
+        with self._lock:
+            now = self.time_func()
+            entry = self._entry(key)
+            if entry["failures"] == 0 or (now - entry["first_failure"]) > self.window_seconds:
+                entry["failures"] = 0
+                entry["first_failure"] = now
+            entry["failures"] += 1
+            if entry["failures"] >= self.max_failures:
+                step_index = min(int(entry["offences"]), len(self.lockout_steps) - 1)
+                entry["locked_until"] = now + self.lockout_steps[step_index]
+                entry["offences"] = min(int(entry["offences"]) + 1, len(self.lockout_steps) - 1)
+                entry["failures"] = 0
+                entry["first_failure"] = 0.0
+
+    def record_success(self, key: str) -> None:
+        """
+        Clear the failure record for a key.
+
+        :param key:
+        :return:
+        """
+        with self._lock:
+            self._state.pop(key, None)
+
+
+login_throttle = LoginThrottle()

--- a/unmanic/service.py
+++ b/unmanic/service.py
@@ -289,6 +289,11 @@ class RootService:
         # Init the database
         self.db_connection = init_db(settings.get_config_path())
 
+        # Apply any web authentication credentials supplied via the environment
+        from unmanic.libs.webauth import bootstrap as webauth_bootstrap
+
+        webauth_bootstrap.apply_environment_credentials(settings)
+
         # Start all threads
         self.start_threads(settings)
 
@@ -353,6 +358,14 @@ def main():
     parser.add_argument(
         "--install-test-data", action="store_true", help="Install test data (use with --manage-plugins)"
     )
+    parser.add_argument(
+        "--set-password",
+        action="store_true",
+        help="Set the web UI username and password for this installation and enable authentication",
+    )
+    parser.add_argument(
+        "--disable-auth", action="store_true", help="Disable web UI authentication (lockout recovery)"
+    )
     parser.add_argument("--dev", action="store_true", help="Enable developer mode")
     parser.add_argument("--dev-api", nargs="?", help="Enable development against another unmanic support api")
     parser.add_argument("--port", nargs="?", help="Specify the port to run the webserver on")
@@ -365,6 +378,24 @@ def main():
 
     # Configure application from args
     settings = config.Config(port=args.port, address=args.address, unmanic_path=None)
+
+    if args.set_password or args.disable_auth:
+        # Init the DB connection
+        db_connection = init_db(settings.get_config_path())
+
+        from unmanic.libs.webauth import bootstrap as webauth_bootstrap
+
+        if args.set_password:
+            exit_code = webauth_bootstrap.run_set_password(settings)
+        else:
+            exit_code = webauth_bootstrap.run_disable_auth(settings)
+
+        # Stop the DB connection
+        db_connection.stop()
+        while not db_connection.is_stopped():
+            time.sleep(0.2)
+            continue
+        raise SystemExit(exit_code)
 
     if args.manage_plugins:
         # Init the DB connection

--- a/unmanic/webserver/api_v2/__init__.py
+++ b/unmanic/webserver/api_v2/__init__.py
@@ -33,6 +33,7 @@
 from __future__ import absolute_import
 import warnings
 
+from .auth_api import ApiAuthHandler
 from .docs_api import ApiDocsHandler
 from .filebrowser_api import ApiFilebrowserHandler
 from .history_api import ApiHistoryHandler
@@ -49,6 +50,7 @@ from .workers_api import ApiWorkersHandler
 __author__ = 'Josh.5 (jsunnex@gmail.com)'
 
 __all__ = (
+    'ApiAuthHandler',
     'ApiDocsHandler',
     'ApiFilebrowserHandler',
     'ApiHistoryHandler',

--- a/unmanic/webserver/api_v2/auth_api.py
+++ b/unmanic/webserver/api_v2/auth_api.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+from unmanic import config
+from unmanic.libs.logs import UnmanicLogging
+from unmanic.libs.webauth import credentials, guard, sessions
+from unmanic.webserver.api_v2.base_api_handler import BaseApiError, BaseApiHandler
+from unmanic.webserver.api_v2.schema.schemas import (
+    AuthSessionsSuccessSchema,
+    AuthStateSuccessSchema,
+    RequestAuthConfigureSchema,
+    RequestAuthPasswordSchema,
+    RequestAuthSessionRevokeSchema,
+)
+
+
+class ApiAuthHandler(BaseApiHandler):
+    """
+    ApiAuthHandler
+
+    Manage the local web account.
+
+    Unrelated to ApiSessionHandler, which manages the unmanic.app supporter account used
+    to unlock features.
+    """
+
+    config = None
+    params = None
+    logger = None
+
+    routes = [
+        {
+            "path_pattern": r"/auth/state",
+            "supported_methods": ["GET"],
+            "call_method": "get_auth_state",
+        },
+        {
+            "path_pattern": r"/auth/configure",
+            "supported_methods": ["POST"],
+            "call_method": "configure_auth",
+        },
+        {
+            "path_pattern": r"/auth/password",
+            "supported_methods": ["POST"],
+            "call_method": "change_password",
+        },
+        {
+            "path_pattern": r"/auth/sessions",
+            "supported_methods": ["GET"],
+            "call_method": "list_auth_sessions",
+        },
+        {
+            "path_pattern": r"/auth/sessions/revoke",
+            "supported_methods": ["POST"],
+            "call_method": "revoke_auth_sessions",
+        },
+    ]
+
+    def initialize(self, **kwargs):
+        self.params = kwargs.get("params")
+        self.config = config.Config()
+        self.logger = UnmanicLogging.get_logger(name=__class__.__name__)
+
+    def __current_token(self):
+        cookie = self.request.cookies.get(sessions.COOKIE_NAME)
+        return getattr(cookie, "value", None) if cookie is not None else None
+
+    async def get_auth_state(self):
+        """
+        Auth - read the current authentication state
+        ---
+        description: Returns whether authentication is enabled and whether this request is authenticated.
+        responses:
+            200:
+                description: 'Sample response: Returns the authentication state.'
+                content:
+                    application/json:
+                        schema:
+                            AuthStateSuccessSchema
+            400:
+                description: Bad request; Check `messages` for any validation errors
+                content:
+                    application/json:
+                        schema:
+                            BadRequestSchema
+            404:
+                description: Bad request; Requested endpoint not found
+                content:
+                    application/json:
+                        schema:
+                            BadEndpointSchema
+            405:
+                description: Bad request; Requested method is not allowed
+                content:
+                    application/json:
+                        schema:
+                            BadMethodSchema
+            500:
+                description: Internal error; Check `error` for exception
+                content:
+                    application/json:
+                        schema:
+                            InternalErrorSchema
+        """
+        try:
+            response = self.build_response(
+                AuthStateSuccessSchema(),
+                {
+                    "enabled": self.config.get_auth_enabled(),
+                    "authenticated": guard.session_from_request(self.request) is not None,
+                    "username": credentials.get_username(),
+                    "allow_basic": self.config.get_auth_allow_basic(),
+                },
+            )
+            self.write_success(response)
+        except BaseApiError as bae:
+            self.logger.error("BaseApiError.%s: %s", self.route.get("call_method"), str(bae))
+            return
+        except Exception as e:
+            self.set_status(self.STATUS_ERROR_INTERNAL, reason=str(e))
+            self.write_error()
+
+    async def configure_auth(self):
+        """
+        Auth - enable or disable authentication
+        ---
+        description: Enable or disable authentication and set the account credentials.
+        requestBody:
+            description: Requested authentication configuration.
+            required: True
+            content:
+                application/json:
+                    schema:
+                        RequestAuthConfigureSchema
+        responses:
+            200:
+                description: 'Successful request; Returns success status'
+                content:
+                    application/json:
+                        schema:
+                            BaseSuccessSchema
+            400:
+                description: Bad request; Check `messages` for any validation errors
+                content:
+                    application/json:
+                        schema:
+                            BadRequestSchema
+            404:
+                description: Bad request; Requested endpoint not found
+                content:
+                    application/json:
+                        schema:
+                            BadEndpointSchema
+            405:
+                description: Bad request; Requested method is not allowed
+                content:
+                    application/json:
+                        schema:
+                            BadMethodSchema
+            500:
+                description: Internal error; Check `error` for exception
+                content:
+                    application/json:
+                        schema:
+                            InternalErrorSchema
+        """
+        try:
+            json_request = self.read_json_request(RequestAuthConfigureSchema())
+            enabled = bool(json_request.get("enabled"))
+
+            if enabled:
+                username = json_request.get("username") or credentials.get_username()
+                password = json_request.get("password")
+                if password:
+                    try:
+                        credentials.set_credential(username, password)
+                    except ValueError as e:
+                        self.set_status(self.STATUS_ERROR_EXTERNAL, reason=str(e))
+                        self.write_error()
+                        return
+                elif not credentials.credential_is_configured():
+                    self.set_status(
+                        self.STATUS_ERROR_EXTERNAL, reason="A password is required to enable authentication"
+                    )
+                    self.write_error()
+                    return
+            else:
+                sessions.revoke_all_sessions()
+
+            self.config.set_config_item("auth_enabled", enabled, save_settings=True)
+            self.logger.info("Web authentication %s via API", "enabled" if enabled else "disabled")
+            self.write_success()
+        except BaseApiError as bae:
+            self.logger.error("BaseApiError.%s: %s", self.route.get("call_method"), str(bae))
+            return
+        except Exception as e:
+            self.set_status(self.STATUS_ERROR_INTERNAL, reason=str(e))
+            self.write_error()
+
+    async def change_password(self):
+        """
+        Auth - change the account password
+        ---
+        description: Change the account password. Revokes every existing session.
+        requestBody:
+            description: Requested password change.
+            required: True
+            content:
+                application/json:
+                    schema:
+                        RequestAuthPasswordSchema
+        responses:
+            200:
+                description: 'Successful request; Returns success status'
+                content:
+                    application/json:
+                        schema:
+                            BaseSuccessSchema
+            400:
+                description: Bad request; Check `messages` for any validation errors
+                content:
+                    application/json:
+                        schema:
+                            BadRequestSchema
+            404:
+                description: Bad request; Requested endpoint not found
+                content:
+                    application/json:
+                        schema:
+                            BadEndpointSchema
+            405:
+                description: Bad request; Requested method is not allowed
+                content:
+                    application/json:
+                        schema:
+                            BadMethodSchema
+            500:
+                description: Internal error; Check `error` for exception
+                content:
+                    application/json:
+                        schema:
+                            InternalErrorSchema
+        """
+        try:
+            json_request = self.read_json_request(RequestAuthPasswordSchema())
+            username = credentials.get_username()
+            if not credentials.verify_credential(username, json_request.get("current_password")):
+                self.set_status(self.STATUS_ERROR_EXTERNAL, reason="Current password is incorrect")
+                self.write_error()
+                return
+            try:
+                credentials.set_credential(username, json_request.get("new_password"))
+            except ValueError as e:
+                self.set_status(self.STATUS_ERROR_EXTERNAL, reason=str(e))
+                self.write_error()
+                return
+
+            # Every session is revoked, then the caller is issued a fresh one so that
+            # changing a password does not sign the person making the change out.
+            from unmanic.webserver.webauth import set_session_cookie
+
+            sessions.revoke_all_sessions()
+            token = sessions.create_session(
+                self.request.remote_ip,
+                self.request.headers.get("User-Agent"),
+                self.config.get_auth_session_idle_timeout_days(),
+                self.config.get_auth_session_max_age_days(),
+            )
+            set_session_cookie(self, token, self.config.get_auth_session_max_age_days())
+            self.logger.info("Web authentication password changed")
+            self.write_success()
+        except BaseApiError as bae:
+            self.logger.error("BaseApiError.%s: %s", self.route.get("call_method"), str(bae))
+            return
+        except Exception as e:
+            self.set_status(self.STATUS_ERROR_INTERNAL, reason=str(e))
+            self.write_error()
+
+    async def list_auth_sessions(self):
+        """
+        Auth - list the live sessions
+        ---
+        description: Returns the live browser sessions for this installation.
+        responses:
+            200:
+                description: 'Sample response: Returns the live sessions.'
+                content:
+                    application/json:
+                        schema:
+                            AuthSessionsSuccessSchema
+            400:
+                description: Bad request; Check `messages` for any validation errors
+                content:
+                    application/json:
+                        schema:
+                            BadRequestSchema
+            404:
+                description: Bad request; Requested endpoint not found
+                content:
+                    application/json:
+                        schema:
+                            BadEndpointSchema
+            405:
+                description: Bad request; Requested method is not allowed
+                content:
+                    application/json:
+                        schema:
+                            BadMethodSchema
+            500:
+                description: Internal error; Check `error` for exception
+                content:
+                    application/json:
+                        schema:
+                            InternalErrorSchema
+        """
+        try:
+            response = self.build_response(
+                AuthSessionsSuccessSchema(),
+                {"sessions": sessions.list_sessions(self.__current_token())},
+            )
+            self.write_success(response)
+        except BaseApiError as bae:
+            self.logger.error("BaseApiError.%s: %s", self.route.get("call_method"), str(bae))
+            return
+        except Exception as e:
+            self.set_status(self.STATUS_ERROR_INTERNAL, reason=str(e))
+            self.write_error()
+
+    async def revoke_auth_sessions(self):
+        """
+        Auth - revoke sessions
+        ---
+        description: Revoke a single session by id, or every session.
+        requestBody:
+            description: Requested session revocation.
+            required: True
+            content:
+                application/json:
+                    schema:
+                        RequestAuthSessionRevokeSchema
+        responses:
+            200:
+                description: 'Successful request; Returns success status'
+                content:
+                    application/json:
+                        schema:
+                            BaseSuccessSchema
+            400:
+                description: Bad request; Check `messages` for any validation errors
+                content:
+                    application/json:
+                        schema:
+                            BadRequestSchema
+            404:
+                description: Bad request; Requested endpoint not found
+                content:
+                    application/json:
+                        schema:
+                            BadEndpointSchema
+            405:
+                description: Bad request; Requested method is not allowed
+                content:
+                    application/json:
+                        schema:
+                            BadMethodSchema
+            500:
+                description: Internal error; Check `error` for exception
+                content:
+                    application/json:
+                        schema:
+                            InternalErrorSchema
+        """
+        try:
+            json_request = self.read_json_request(RequestAuthSessionRevokeSchema())
+            if json_request.get("all"):
+                sessions.revoke_all_sessions()
+            elif json_request.get("id"):
+                sessions.revoke_session_by_id(int(json_request.get("id")))
+            else:
+                self.set_status(self.STATUS_ERROR_EXTERNAL, reason="Either 'id' or 'all' is required")
+                self.write_error()
+                return
+            self.write_success()
+        except BaseApiError as bae:
+            self.logger.error("BaseApiError.%s: %s", self.route.get("call_method"), str(bae))
+            return
+        except Exception as e:
+            self.set_status(self.STATUS_ERROR_INTERNAL, reason=str(e))
+            self.write_error()

--- a/unmanic/webserver/api_v2/schema/schemas.py
+++ b/unmanic/webserver/api_v2/schema/schemas.py
@@ -1924,3 +1924,94 @@ class WorkerStatusSuccessSchema(BaseSchema):
         many=True,
         validate=validate.Length(min=0),
     )
+
+
+class AuthStateSuccessSchema(BaseSchema):
+    """Schema for the current authentication state"""
+
+    enabled = fields.Boolean(
+        required=True,
+        description="Whether authentication is enabled on this installation",
+        example=False,
+    )
+    authenticated = fields.Boolean(
+        required=True,
+        description="Whether the current request is authenticated",
+        example=True,
+    )
+    username = fields.Str(
+        required=False,
+        allow_none=True,
+        description="The configured username",
+        example="jordan",
+    )
+    allow_basic = fields.Boolean(
+        required=True,
+        description="Whether HTTP Basic authentication is accepted for API requests",
+        example=True,
+    )
+
+
+class RequestAuthConfigureSchema(BaseSchema):
+    """Schema for enabling or disabling authentication"""
+
+    enabled = fields.Boolean(
+        required=True,
+        description="Enable or disable authentication",
+        example=True,
+    )
+    username = fields.Str(
+        required=False,
+        load_default="",
+        description="The username to configure",
+        example="jordan",
+    )
+    password = fields.Str(
+        required=False,
+        load_default="",
+        description="The password to configure",
+        example="a-good-password",
+    )
+
+
+class RequestAuthPasswordSchema(BaseSchema):
+    """Schema for changing the account password"""
+
+    current_password = fields.Str(
+        required=True,
+        description="The current password",
+        example="a-good-password",
+    )
+    new_password = fields.Str(
+        required=True,
+        description="The replacement password",
+        example="another-good-password",
+    )
+
+
+class AuthSessionsSuccessSchema(BaseSchema):
+    """Schema listing the live browser sessions"""
+
+    sessions = fields.List(
+        fields.Dict(),
+        required=True,
+        description="The live sessions for this installation",
+        example=[],
+    )
+
+
+class RequestAuthSessionRevokeSchema(BaseSchema):
+    """Schema for revoking sessions"""
+
+    id = fields.Int(
+        required=False,
+        allow_none=True,
+        description="The session id to revoke",
+        example=1,
+    )
+    all = fields.Boolean(
+        required=False,
+        load_default=False,
+        description="Revoke every session",
+        example=False,
+    )

--- a/unmanic/webserver/templates/auth/login.html
+++ b/unmanic/webserver/templates/auth/login.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Sign in - Unmanic</title>
+    <style>
+        :root { color-scheme: dark; }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
+            background: #1d1d1d; color: #e0e0e0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        }
+        .card { width: 100%; max-width: 22rem; padding: 2rem; background: #272727; border-radius: 6px; }
+        h1 { margin: 0 0 0.25rem; font-size: 1.3rem; font-weight: 600; }
+        p.sub { margin: 0 0 1.5rem; font-size: 0.85rem; color: #9e9e9e; }
+        label { display: block; margin-bottom: 0.35rem; font-size: 0.8rem; color: #bdbdbd; }
+        input {
+            width: 100%; padding: 0.6rem; margin-bottom: 1rem; font-size: 1rem;
+            color: #e0e0e0; background: #1d1d1d; border: 1px solid #424242; border-radius: 4px;
+        }
+        input:focus { outline: none; border-color: #1976d2; }
+        button {
+            width: 100%; padding: 0.65rem; font-size: 1rem; font-weight: 600; cursor: pointer;
+            color: #fff; background: #1976d2; border: 0; border-radius: 4px;
+        }
+        button:hover { background: #1565c0; }
+        .error {
+            padding: 0.6rem; margin-bottom: 1rem; font-size: 0.85rem;
+            color: #ff8a80; background: rgba(255, 138, 128, 0.12); border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+<div class="card">
+    <h1>Unmanic</h1>
+    <p class="sub">Sign in to this installation</p>
+    {% if error %}
+    <div class="error">{{ error }}</div>
+    {% end %}
+    <form method="POST" action="/unmanic/auth/login">
+        <input type="hidden" name="next" value="{{ next_path }}">
+        <label for="username">Username</label>
+        <input id="username" name="username" type="text" autocomplete="username" autofocus required>
+        <label for="password">Password</label>
+        <input id="password" name="password" type="password" autocomplete="current-password" required>
+        <button type="submit">Sign in</button>
+    </form>
+</div>
+</body>
+</html>

--- a/unmanic/webserver/templates/auth/login.html
+++ b/unmanic/webserver/templates/auth/login.html
@@ -6,48 +6,90 @@
     <meta name="robots" content="noindex, nofollow">
     <title>Sign in - Unmanic</title>
     <style>
-        :root { color-scheme: dark; }
+        /*
+         * Styles are inlined and duplicated across the auth templates on purpose. These
+         * pages are served before authentication, so keeping them self-contained means no
+         * static path has to be opened up in the request guard's allowlist.
+         *
+         * Colours track src/css/quasar.variables.scss in the unmanic-frontend project:
+         *   $primary #002e5c   $secondary #009fdd   $dark #181818
+         *   $negative #C10015  $warning #F2C037     $positive #21BA45
+         */
+        :root {
+            color-scheme: dark;
+            --unmanic-page: #121212;
+            --unmanic-surface: #181818;
+            --unmanic-primary: #002e5c;
+            --unmanic-secondary: #009fdd;
+            --unmanic-secondary-hover: #0089c0;
+            --unmanic-text: #ffffff;
+            --unmanic-text-muted: #bdbdbd;
+            --unmanic-text-faint: #9e9e9e;
+            --unmanic-border: rgba(255, 255, 255, 0.24);
+            --unmanic-negative: #ff5252;
+        }
         * { box-sizing: border-box; }
         body {
             margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
-            background: #1d1d1d; color: #e0e0e0;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            padding: 1rem;
+            background: var(--unmanic-page); color: var(--unmanic-text);
+            font-family: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
         }
-        .card { width: 100%; max-width: 22rem; padding: 2rem; background: #272727; border-radius: 6px; }
-        h1 { margin: 0 0 0.25rem; font-size: 1.3rem; font-weight: 600; }
-        p.sub { margin: 0 0 1.5rem; font-size: 0.85rem; color: #9e9e9e; }
-        label { display: block; margin-bottom: 0.35rem; font-size: 0.8rem; color: #bdbdbd; }
+        .card {
+            width: 100%; max-width: 22rem; overflow: hidden;
+            background: var(--unmanic-surface); border-radius: 4px;
+            box-shadow: 0 1px 5px rgba(0, 0, 0, 0.2), 0 2px 2px rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.12);
+        }
+        .card-head { padding: 1.25rem 2rem; background: var(--unmanic-primary); }
+        .card-body { padding: 1.75rem 2rem 2rem; }
+        h1 { margin: 0; font-size: 1.25rem; font-weight: 500; letter-spacing: 0.01em; }
+        p.sub { margin: 0.2rem 0 0; font-size: 0.8rem; color: rgba(255, 255, 255, 0.7); }
+        label {
+            display: block; margin-bottom: 0.35rem;
+            font-size: 0.75rem; font-weight: 500; letter-spacing: 0.02em; color: var(--unmanic-text-muted);
+        }
         input {
-            width: 100%; padding: 0.6rem; margin-bottom: 1rem; font-size: 1rem;
-            color: #e0e0e0; background: #1d1d1d; border: 1px solid #424242; border-radius: 4px;
+            width: 100%; padding: 0.65rem 0.75rem; margin-bottom: 1.1rem; font-size: 1rem;
+            font-family: inherit; color: var(--unmanic-text); background: var(--unmanic-page);
+            border: 1px solid var(--unmanic-border); border-radius: 4px;
+            transition: border-color 0.2s ease;
         }
-        input:focus { outline: none; border-color: #1976d2; }
+        input:focus { outline: none; border-color: var(--unmanic-secondary); }
         button {
-            width: 100%; padding: 0.65rem; font-size: 1rem; font-weight: 600; cursor: pointer;
-            color: #fff; background: #1976d2; border: 0; border-radius: 4px;
+            width: 100%; padding: 0.7rem; margin-top: 0.4rem; cursor: pointer;
+            font-family: inherit; font-size: 0.875rem; font-weight: 500;
+            text-transform: uppercase; letter-spacing: 0.09em;
+            color: #fff; background: var(--unmanic-secondary); border: 0; border-radius: 4px;
+            transition: background 0.2s ease;
         }
-        button:hover { background: #1565c0; }
+        button:hover { background: var(--unmanic-secondary-hover); }
+        button:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
         .error {
-            padding: 0.6rem; margin-bottom: 1rem; font-size: 0.85rem;
-            color: #ff8a80; background: rgba(255, 138, 128, 0.12); border-radius: 4px;
+            padding: 0.65rem 0.75rem; margin-bottom: 1.1rem; font-size: 0.8rem; line-height: 1.4;
+            color: var(--unmanic-negative); background: rgba(193, 0, 21, 0.14);
+            border-left: 3px solid var(--unmanic-negative); border-radius: 2px;
         }
     </style>
 </head>
 <body>
 <div class="card">
-    <h1>Unmanic</h1>
-    <p class="sub">Sign in to this installation</p>
-    {% if error %}
-    <div class="error">{{ error }}</div>
-    {% end %}
-    <form method="POST" action="/unmanic/auth/login">
-        <input type="hidden" name="next" value="{{ next_path }}">
-        <label for="username">Username</label>
-        <input id="username" name="username" type="text" autocomplete="username" autofocus required>
-        <label for="password">Password</label>
-        <input id="password" name="password" type="password" autocomplete="current-password" required>
-        <button type="submit">Sign in</button>
-    </form>
+    <div class="card-head">
+        <h1>Unmanic</h1>
+        <p class="sub">Sign in to this installation</p>
+    </div>
+    <div class="card-body">
+        {% if error %}
+        <div class="error">{{ error }}</div>
+        {% end %}
+        <form method="POST" action="/unmanic/auth/login">
+            <input type="hidden" name="next" value="{{ next_path }}">
+            <label for="username">Username</label>
+            <input id="username" name="username" type="text" autocomplete="username" autofocus required>
+            <label for="password">Password</label>
+            <input id="password" name="password" type="password" autocomplete="current-password" required>
+            <button type="submit">Sign in</button>
+        </form>
+    </div>
 </div>
 </body>
 </html>

--- a/unmanic/webserver/templates/auth/setup.html
+++ b/unmanic/webserver/templates/auth/setup.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Set up sign in - Unmanic</title>
+    <style>
+        :root { color-scheme: dark; }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
+            background: #1d1d1d; color: #e0e0e0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        }
+        .card { width: 100%; max-width: 22rem; padding: 2rem; background: #272727; border-radius: 6px; }
+        h1 { margin: 0 0 0.25rem; font-size: 1.3rem; font-weight: 600; }
+        p.sub { margin: 0 0 1.5rem; font-size: 0.85rem; color: #9e9e9e; }
+        label { display: block; margin-bottom: 0.35rem; font-size: 0.8rem; color: #bdbdbd; }
+        input {
+            width: 100%; padding: 0.6rem; margin-bottom: 1rem; font-size: 1rem;
+            color: #e0e0e0; background: #1d1d1d; border: 1px solid #424242; border-radius: 4px;
+        }
+        input:focus { outline: none; border-color: #1976d2; }
+        button {
+            width: 100%; padding: 0.65rem; font-size: 1rem; font-weight: 600; cursor: pointer;
+            color: #fff; background: #1976d2; border: 0; border-radius: 4px;
+        }
+        button:hover { background: #1565c0; }
+        .error {
+            padding: 0.6rem; margin-bottom: 1rem; font-size: 0.85rem;
+            color: #ff8a80; background: rgba(255, 138, 128, 0.12); border-radius: 4px;
+        }
+        .note { margin-top: 1.25rem; font-size: 0.75rem; line-height: 1.5; color: #9e9e9e; }
+    </style>
+</head>
+<body>
+<div class="card">
+    <h1>Set up sign in</h1>
+    <p class="sub">Choose the credentials for this Unmanic installation</p>
+    {% if error %}
+    <div class="error">{{ error }}</div>
+    {% end %}
+    <form method="POST" action="/unmanic/auth/setup">
+        <label for="username">Username</label>
+        <input id="username" name="username" type="text" autocomplete="username" autofocus required>
+        <label for="password">Password</label>
+        <input id="password" name="password" type="password" autocomplete="new-password" required minlength="8">
+        <label for="confirm">Confirm password</label>
+        <input id="confirm" name="confirm" type="password" autocomplete="new-password" required minlength="8">
+        <button type="submit">Save and sign in</button>
+    </form>
+    <p class="note">
+        This protects Unmanic from others on your network. It does not make Unmanic safe to
+        expose to the internet - use a VPN or an authenticating reverse proxy for that.
+    </p>
+</div>
+</body>
+</html>

--- a/unmanic/webserver/templates/auth/setup.html
+++ b/unmanic/webserver/templates/auth/setup.html
@@ -6,54 +6,230 @@
     <meta name="robots" content="noindex, nofollow">
     <title>Set up sign in - Unmanic</title>
     <style>
-        :root { color-scheme: dark; }
+        /*
+         * Styles are inlined and duplicated across the auth templates on purpose. These
+         * pages are served before authentication, so keeping them self-contained means no
+         * static path has to be opened up in the request guard's allowlist.
+         *
+         * Colours track src/css/quasar.variables.scss in the unmanic-frontend project:
+         *   $primary #002e5c   $secondary #009fdd   $dark #181818
+         *   $negative #C10015  $warning #F2C037     $positive #21BA45
+         */
+        :root {
+            color-scheme: dark;
+            --unmanic-page: #121212;
+            --unmanic-surface: #181818;
+            --unmanic-primary: #002e5c;
+            --unmanic-secondary: #009fdd;
+            --unmanic-secondary-hover: #0089c0;
+            --unmanic-text: #ffffff;
+            --unmanic-text-muted: #bdbdbd;
+            --unmanic-text-faint: #9e9e9e;
+            --unmanic-border: rgba(255, 255, 255, 0.24);
+            /* Lightened from $negative #C10015, which only reaches 2.8:1 on this surface. */
+            --unmanic-negative: #ff5252;
+            --unmanic-warning: #f2c037;
+            --unmanic-positive: #21ba45;
+        }
         * { box-sizing: border-box; }
         body {
             margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
-            background: #1d1d1d; color: #e0e0e0;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            padding: 1rem;
+            background: var(--unmanic-page); color: var(--unmanic-text);
+            font-family: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
         }
-        .card { width: 100%; max-width: 22rem; padding: 2rem; background: #272727; border-radius: 6px; }
-        h1 { margin: 0 0 0.25rem; font-size: 1.3rem; font-weight: 600; }
-        p.sub { margin: 0 0 1.5rem; font-size: 0.85rem; color: #9e9e9e; }
-        label { display: block; margin-bottom: 0.35rem; font-size: 0.8rem; color: #bdbdbd; }
+        .card {
+            width: 100%; max-width: 22rem; overflow: hidden;
+            background: var(--unmanic-surface); border-radius: 4px;
+            box-shadow: 0 1px 5px rgba(0, 0, 0, 0.2), 0 2px 2px rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.12);
+        }
+        .card-head { padding: 1.25rem 2rem; background: var(--unmanic-primary); }
+        .card-body { padding: 1.75rem 2rem 2rem; }
+        h1 { margin: 0; font-size: 1.25rem; font-weight: 500; letter-spacing: 0.01em; }
+        p.sub { margin: 0.2rem 0 0; font-size: 0.8rem; color: rgba(255, 255, 255, 0.7); }
+        label {
+            display: block; margin-bottom: 0.35rem;
+            font-size: 0.75rem; font-weight: 500; letter-spacing: 0.02em; color: var(--unmanic-text-muted);
+        }
         input {
-            width: 100%; padding: 0.6rem; margin-bottom: 1rem; font-size: 1rem;
-            color: #e0e0e0; background: #1d1d1d; border: 1px solid #424242; border-radius: 4px;
+            width: 100%; padding: 0.65rem 0.75rem; margin-bottom: 0.35rem; font-size: 1rem;
+            font-family: inherit; color: var(--unmanic-text); background: var(--unmanic-page);
+            border: 1px solid var(--unmanic-border); border-radius: 4px;
+            transition: border-color 0.2s ease;
         }
-        input:focus { outline: none; border-color: #1976d2; }
+        input:focus { outline: none; border-color: var(--unmanic-secondary); }
+        input.invalid { border-color: var(--unmanic-negative); }
+        .hint {
+            display: block; min-height: 1.1rem; margin-bottom: 0.85rem;
+            font-size: 0.72rem; line-height: 1.45; color: var(--unmanic-text-faint);
+        }
+        .hint.bad { color: var(--unmanic-negative); }
+        .hint.warn { color: var(--unmanic-warning); }
+        .hint.ok { color: var(--unmanic-positive); }
         button {
-            width: 100%; padding: 0.65rem; font-size: 1rem; font-weight: 600; cursor: pointer;
-            color: #fff; background: #1976d2; border: 0; border-radius: 4px;
+            width: 100%; padding: 0.7rem; margin-top: 0.4rem; cursor: pointer;
+            font-family: inherit; font-size: 0.875rem; font-weight: 500;
+            text-transform: uppercase; letter-spacing: 0.09em;
+            color: #fff; background: var(--unmanic-secondary); border: 0; border-radius: 4px;
+            transition: background 0.2s ease;
         }
-        button:hover { background: #1565c0; }
+        button:hover { background: var(--unmanic-secondary-hover); }
+        button:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
         .error {
-            padding: 0.6rem; margin-bottom: 1rem; font-size: 0.85rem;
-            color: #ff8a80; background: rgba(255, 138, 128, 0.12); border-radius: 4px;
+            padding: 0.65rem 0.75rem; margin-bottom: 1.1rem; font-size: 0.8rem; line-height: 1.4;
+            color: var(--unmanic-negative); background: rgba(193, 0, 21, 0.14);
+            border-left: 3px solid var(--unmanic-negative); border-radius: 2px;
         }
-        .note { margin-top: 1.25rem; font-size: 0.75rem; line-height: 1.5; color: #9e9e9e; }
+        .note {
+            margin: 1.4rem 0 0; padding-top: 1.1rem; font-size: 0.72rem; line-height: 1.55;
+            color: var(--unmanic-text-faint); border-top: 1px solid rgba(255, 255, 255, 0.08);
+        }
     </style>
 </head>
 <body>
 <div class="card">
-    <h1>Set up sign in</h1>
-    <p class="sub">Choose the credentials for this Unmanic installation</p>
-    {% if error %}
-    <div class="error">{{ error }}</div>
-    {% end %}
-    <form method="POST" action="/unmanic/auth/setup">
-        <label for="username">Username</label>
-        <input id="username" name="username" type="text" autocomplete="username" autofocus required>
-        <label for="password">Password</label>
-        <input id="password" name="password" type="password" autocomplete="new-password" required minlength="8">
-        <label for="confirm">Confirm password</label>
-        <input id="confirm" name="confirm" type="password" autocomplete="new-password" required minlength="8">
-        <button type="submit">Save and sign in</button>
-    </form>
-    <p class="note">
-        This protects Unmanic from others on your network. It does not make Unmanic safe to
-        expose to the internet - use a VPN or an authenticating reverse proxy for that.
-    </p>
+    <div class="card-head">
+        <h1>Set up sign in</h1>
+        <p class="sub">Choose the credentials for this installation</p>
+    </div>
+    <div class="card-body">
+        {% if error %}
+        <div class="error">{{ error }}</div>
+        {% end %}
+        <form id="setup-form" method="POST" action="/unmanic/auth/setup">
+            <label for="username">Username</label>
+            <input id="username" name="username" type="text" autocomplete="username" autofocus required>
+            <span id="username-hint" class="hint" aria-live="polite"></span>
+
+            <label for="password">Password</label>
+            <input id="password" name="password" type="password" autocomplete="new-password" required minlength="8">
+            <span id="password-hint" class="hint" aria-live="polite"></span>
+
+            <label for="confirm">Confirm password</label>
+            <input id="confirm" name="confirm" type="password" autocomplete="new-password" required minlength="8">
+            <span id="confirm-hint" class="hint" aria-live="polite"></span>
+
+            <button type="submit">Save and sign in</button>
+        </form>
+        <p class="note">
+            This protects Unmanic from others on your network. It does not make Unmanic safe to
+            expose to the internet - use a VPN or an authenticating reverse proxy for that.
+        </p>
+    </div>
 </div>
+<script>
+    (function () {
+        var MIN_LENGTH = 8;
+        var MAX_LENGTH = 128;
+
+        var form = document.getElementById("setup-form");
+        var username = document.getElementById("username");
+        var password = document.getElementById("password");
+        var confirmField = document.getElementById("confirm");
+        var usernameHint = document.getElementById("username-hint");
+        var passwordHint = document.getElementById("password-hint");
+        var confirmHint = document.getElementById("confirm-hint");
+
+        function setHint(field, hint, text, state) {
+            hint.textContent = text;
+            hint.className = state ? "hint " + state : "hint";
+            if (state === "bad") {
+                field.classList.add("invalid");
+            } else {
+                field.classList.remove("invalid");
+            }
+        }
+
+        // Advisory only. The server enforces length, not composition, following NIST
+        // guidance that length matters more than character-class rules. A weak password is
+        // never blocked here - blocking it would apply a rule the server does not.
+        function describeStrength(value) {
+            var classes = 0;
+            if (/[a-z]/.test(value)) { classes += 1; }
+            if (/[A-Z]/.test(value)) { classes += 1; }
+            if (/[0-9]/.test(value)) { classes += 1; }
+            if (/[^A-Za-z0-9]/.test(value)) { classes += 1; }
+
+            if (value.length >= 16 || (value.length >= 12 && classes >= 3)) {
+                return ["Strong.", "ok"];
+            }
+            if (value.length >= 12 || classes >= 3) {
+                return ["Reasonable. Extra length helps more than extra symbols.", "ok"];
+            }
+            return ["Weak, but allowed. A longer passphrase beats added symbols.", "warn"];
+        }
+
+        function checkUsername(showEmptyError) {
+            if (!username.value.trim()) {
+                setHint(username, usernameHint, showEmptyError ? "A username is required." : "", showEmptyError ? "bad" : "");
+                return false;
+            }
+            setHint(username, usernameHint, "", "");
+            return true;
+        }
+
+        function checkPassword() {
+            var value = password.value;
+            if (!value) {
+                setHint(password, passwordHint, "At least " + MIN_LENGTH + " characters.", "");
+                return false;
+            }
+            if (value.length < MIN_LENGTH) {
+                var missing = MIN_LENGTH - value.length;
+                var noun = missing === 1 ? " more character needed." : " more characters needed.";
+                setHint(password, passwordHint, "Too short - " + missing + noun, "bad");
+                return false;
+            }
+            if (value.length > MAX_LENGTH) {
+                setHint(password, passwordHint, "Too long - maximum " + MAX_LENGTH + " characters.", "bad");
+                return false;
+            }
+            var described = describeStrength(value);
+            setHint(password, passwordHint, described[0], described[1]);
+            return true;
+        }
+
+        function checkConfirm() {
+            if (!confirmField.value) {
+                setHint(confirmField, confirmHint, "", "");
+                return false;
+            }
+            if (confirmField.value !== password.value) {
+                setHint(confirmField, confirmHint, "Passwords do not match.", "bad");
+                return false;
+            }
+            setHint(confirmField, confirmHint, "Passwords match.", "ok");
+            return true;
+        }
+
+        username.addEventListener("input", function () { checkUsername(false); });
+        password.addEventListener("input", function () {
+            checkPassword();
+            if (confirmField.value) {
+                checkConfirm();
+            }
+        });
+        confirmField.addEventListener("input", checkConfirm);
+
+        form.addEventListener("submit", function (event) {
+            var usernameOk = checkUsername(true);
+            var passwordOk = checkPassword();
+            var confirmOk = checkConfirm();
+            if (usernameOk && passwordOk && confirmOk) {
+                return;
+            }
+            event.preventDefault();
+            if (!usernameOk) {
+                username.focus();
+            } else if (!passwordOk) {
+                password.focus();
+            } else {
+                confirmField.focus();
+            }
+        });
+
+        checkPassword();
+    })();
+</script>
 </body>
 </html>

--- a/unmanic/webserver/webauth.py
+++ b/unmanic/webserver/webauth.py
@@ -28,13 +28,28 @@ class AuthTemplateMixin(object):
     """
     AuthTemplateMixin
 
-    The application-wide template_loader points at the built frontend directory and takes
-    precedence over get_template_path(), so the loader itself must be replaced. Overriding
-    get_template_path() alone silently has no effect.
+    Renders templates from unmanic/webserver/templates rather than from the built
+    frontend directory.
+
+    Both methods below must be overridden, for two separate reasons:
+
+    - create_template_loader, because the application-wide 'template_loader' setting
+      points at the built frontend and the default implementation returns it regardless
+      of the template path.
+    - get_template_path, because Tornado caches loaders in RequestHandler
+      ._template_loaders, a dict shared by every handler in the process and keyed by
+      template path. With no template path set, Tornado derives that key from the
+      calling module's directory - which for this module is unmanic/webserver, exactly
+      the same key MainUIRequestHandler in main.py derives. Without this override the
+      auth loader is cached under that shared key and the whole frontend starts looking
+      for index.html inside the auth template directory.
     """
 
+    def get_template_path(self):
+        return TEMPLATE_ROOT
+
     def create_template_loader(self, template_path):
-        return tornado.template.Loader(TEMPLATE_ROOT)
+        return tornado.template.Loader(template_path)
 
 
 def set_session_cookie(handler, token, max_age_days):

--- a/unmanic/webserver/webauth.py
+++ b/unmanic/webserver/webauth.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (C) Josh Sunnex
+
+SPDX-License-Identifier: GPL-3.0-only
+"""
+
+import tornado.web
+
+
+class AuthFailureHandler(tornado.web.RequestHandler):
+    """
+    AuthFailureHandler
+
+    Terminates any request the guard refused. Every HTTP method lands here, so a rejected
+    request can never fall through to a real handler.
+    """
+
+    SUPPORTED_METHODS = ("GET", "HEAD", "POST", "DELETE", "PATCH", "PUT", "OPTIONS")
+
+    def initialize(self, decision=None):
+        self.decision = decision
+
+    def _respond(self):
+        decision = self.decision
+        if decision is not None and decision.status == 302 and decision.redirect_to:
+            self.redirect(decision.redirect_to)
+            return
+        status = 401 if decision is None else decision.status
+        reason = "Unauthorized" if decision is None else (decision.reason or "Unauthorized")
+        if decision is not None and decision.retry_after:
+            self.set_header("Retry-After", str(decision.retry_after))
+        # No WWW-Authenticate header is ever sent. Browsers must never cache Basic
+        # credentials, or Basic would become an ambient credential and a CSRF vector.
+        self.set_status(status)
+        self.set_header("Content-Type", 'application/json; charset="utf-8"')
+        self.finish({"error": "{}: {}".format(status, reason)})
+
+    def get(self, *args, **kwargs):
+        self._respond()
+
+    def head(self, *args, **kwargs):
+        self._respond()
+
+    def post(self, *args, **kwargs):
+        self._respond()
+
+    def delete(self, *args, **kwargs):
+        self._respond()
+
+    def patch(self, *args, **kwargs):
+        self._respond()
+
+    def put(self, *args, **kwargs):
+        self._respond()
+
+    def options(self, *args, **kwargs):
+        self._respond()

--- a/unmanic/webserver/webauth.py
+++ b/unmanic/webserver/webauth.py
@@ -7,7 +7,77 @@ Copyright (C) Josh Sunnex
 SPDX-License-Identifier: GPL-3.0-only
 """
 
+import os
+
+import tornado.template
 import tornado.web
+
+from unmanic import config
+from unmanic.libs.logs import UnmanicLogging
+from unmanic.libs.webauth import credentials, guard, sessions
+from unmanic.libs.webauth.throttle import login_throttle
+
+logger = UnmanicLogging.get_logger(name="WebAuth")
+
+TEMPLATE_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
+
+GENERIC_LOGIN_ERROR = "Invalid username or password"
+
+
+class AuthTemplateMixin(object):
+    """
+    AuthTemplateMixin
+
+    The application-wide template_loader points at the built frontend directory and takes
+    precedence over get_template_path(), so the loader itself must be replaced. Overriding
+    get_template_path() alone silently has no effect.
+    """
+
+    def create_template_loader(self, template_path):
+        return tornado.template.Loader(TEMPLATE_ROOT)
+
+
+def set_session_cookie(handler, token, max_age_days):
+    """
+    Write the session cookie.
+
+    :param handler:
+    :param token:
+    :param max_age_days:
+    :return:
+    """
+    settings = config.Config()
+    kwargs = {
+        "httponly": True,
+        "path": "/",
+        "expires_days": int(max_age_days),
+        "samesite": "Lax",
+    }
+    if settings.get_ssl_enabled():
+        # Only set Secure when TLS is on. Setting it over plain HTTP would stop the cookie
+        # ever being sent and lock out every LAN user.
+        kwargs["secure"] = True
+    handler.set_cookie(sessions.COOKIE_NAME, token, **kwargs)
+
+
+def clear_session_cookie(handler):
+    """
+    Remove the session cookie.
+
+    :param handler:
+    :return:
+    """
+    handler.clear_cookie(sessions.COOKIE_NAME, path="/")
+
+
+def throttle_key(handler):
+    """
+    Build the throttle key for a request.
+
+    :param handler:
+    :return:
+    """
+    return "login:{}".format(handler.request.remote_ip)
 
 
 class AuthFailureHandler(tornado.web.RequestHandler):
@@ -58,3 +128,90 @@ class AuthFailureHandler(tornado.web.RequestHandler):
 
     def options(self, *args, **kwargs):
         self._respond()
+
+
+class LoginPageHandler(AuthTemplateMixin, tornado.web.RequestHandler):
+    """
+    LoginPageHandler
+
+    Serves the sign-in page.
+    """
+
+    SUPPORTED_METHODS = ("GET", "HEAD")
+
+    def get(self):
+        if guard.session_from_request(self.request) is not None:
+            self.redirect(guard.safe_next_path(self.get_argument("next", None)))
+            return
+        self.set_header("Content-Type", "text/html; charset=UTF-8")
+        self.render(
+            "auth/login.html",
+            error=None,
+            next_path=guard.safe_next_path(self.get_argument("next", None)),
+        )
+
+
+class LoginActionHandler(AuthTemplateMixin, tornado.web.RequestHandler):
+    """
+    LoginActionHandler
+
+    Validates a sign-in attempt and issues a session.
+    """
+
+    SUPPORTED_METHODS = ("POST",)
+
+    def post(self):
+        settings = config.Config()
+        key = throttle_key(self)
+        next_path = guard.safe_next_path(self.get_argument("next", None))
+
+        retry_after = login_throttle.retry_after(key)
+        if retry_after:
+            logger.warning(
+                "Web authentication locked out for %s for a further %s seconds",
+                self.request.remote_ip,
+                retry_after,
+            )
+            self.set_status(429)
+            self.set_header("Retry-After", str(retry_after))
+            self.render("auth/login.html", error="Too many attempts. Try again later.", next_path=next_path)
+            return
+
+        username = self.get_argument("username", "")
+        password = self.get_argument("password", "")
+
+        if not credentials.verify_credential(username, password):
+            login_throttle.record_failure(key)
+            logger.warning("Failed web authentication attempt from %s", self.request.remote_ip)
+            self.set_status(401)
+            self.render("auth/login.html", error=GENERIC_LOGIN_ERROR, next_path=next_path)
+            return
+
+        login_throttle.record_success(key)
+        sessions.purge_expired()
+        token = sessions.create_session(
+            self.request.remote_ip,
+            self.request.headers.get("User-Agent"),
+            settings.get_auth_session_idle_timeout_days(),
+            settings.get_auth_session_max_age_days(),
+        )
+        set_session_cookie(self, token, settings.get_auth_session_max_age_days())
+        logger.info("Successful web authentication from %s", self.request.remote_ip)
+        self.redirect(next_path)
+
+
+class LogoutActionHandler(tornado.web.RequestHandler):
+    """
+    LogoutActionHandler
+
+    Revokes the current session. POST only, so an image tag cannot trigger it.
+    """
+
+    SUPPORTED_METHODS = ("POST",)
+
+    def post(self):
+        cookie = self.request.cookies.get(sessions.COOKIE_NAME)
+        if cookie is not None and getattr(cookie, "value", None):
+            sessions.revoke_session(cookie.value)
+        clear_session_cookie(self)
+        self.redirect(guard.LOGIN_PATH)

--- a/unmanic/webserver/webauth.py
+++ b/unmanic/webserver/webauth.py
@@ -215,3 +215,68 @@ class LogoutActionHandler(tornado.web.RequestHandler):
             sessions.revoke_session(cookie.value)
         clear_session_cookie(self)
         self.redirect(guard.LOGIN_PATH)
+
+
+class SetupPageHandler(AuthTemplateMixin, tornado.web.RequestHandler):
+    """
+    SetupPageHandler
+
+    Serves the first-run credential setup page. The guard only routes here while no
+    credential exists; once one does it answers 404 without reaching this handler.
+    """
+
+    SUPPORTED_METHODS = ("GET", "HEAD")
+
+    def get(self):
+        self.set_header("Content-Type", "text/html; charset=UTF-8")
+        self.render("auth/setup.html", error=None)
+
+
+class SetupActionHandler(AuthTemplateMixin, tornado.web.RequestHandler):
+    """
+    SetupActionHandler
+
+    Creates the first credential and signs the browser in.
+    """
+
+    SUPPORTED_METHODS = ("POST",)
+
+    def post(self):
+        settings = config.Config()
+        key = throttle_key(self)
+
+        retry_after = login_throttle.retry_after(key)
+        if retry_after:
+            self.set_status(429)
+            self.set_header("Retry-After", str(retry_after))
+            self.render("auth/setup.html", error="Too many attempts. Try again later.")
+            return
+
+        username = self.get_argument("username", "")
+        password = self.get_argument("password", "")
+        confirm = self.get_argument("confirm", "")
+
+        if password != confirm:
+            login_throttle.record_failure(key)
+            self.set_status(400)
+            self.render("auth/setup.html", error="The passwords entered did not match")
+            return
+
+        try:
+            credentials.set_credential(username, password)
+        except ValueError as e:
+            login_throttle.record_failure(key)
+            self.set_status(400)
+            self.render("auth/setup.html", error=str(e))
+            return
+
+        login_throttle.record_success(key)
+        token = sessions.create_session(
+            self.request.remote_ip,
+            self.request.headers.get("User-Agent"),
+            settings.get_auth_session_idle_timeout_days(),
+            settings.get_auth_session_max_age_days(),
+        )
+        set_session_cookie(self, token, settings.get_auth_session_max_age_days())
+        logger.info("Web authentication credentials configured from %s", self.request.remote_ip)
+        self.redirect(guard.DEFAULT_LANDING_PATH)


### PR DESCRIPTION
# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership
of my work contained in that pull request to the Unmanic project and the project
owner. My contribution will become licensed under the same license as the overall project.
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist

- [x] I have ensured that my pull request is being opened to merge into the staging branch.

- [x] I have ensured that all new python file contributions contain the correct header as
stipulated in the [Contributing Docs](CONTRIBUTING.md).


## Description of the pull request

> **Note on authorship:** this contribution was co-authored with AI (Claude). I set the
> direction, made the design calls, reviewed every change, and tested it against my own
> installation before opening this. The reasoning behind each decision is written up below
> rather than left implicit, and I am happy to talk through any part of it or rework anything
> that does not suit the project.

## Quick Summary

Adds a username and password to the Unmanic web UI and API. A new installation asks you to set
one on first run. An installation that has run before is left exactly as it is, and can opt in
whenever it suits.

Right now there is no way to put a password on Unmanic. Anyone who can reach the port can
browse the host filesystem through the file browser, delete files from the library, and
reconfigure workers. On a home network that means guests, a housemate's laptop, or a
compromised smart TV all have full control. This closes #40, which has been open since 2019.

I want to be straight about what this is not, because it is the reason the idea was turned
down in #410. This does not make Unmanic safe to put on the internet, and nothing in the PR
claims otherwise. Unmanic runs ffmpeg against paths it controls and exposes a filesystem
browser, so one authentication bypass is a compromised host rather than an inconvenience. The
documentation says exactly that, and still points people at a VPN or an authenticating reverse
proxy for remote access. What this is for is LAN hygiene: stopping everything else on your
network from having admin rights on your media server.

That distinction also drove the scope. A password alone would have been the false sense of
security described in #410, because a malicious web page open in any browser on the network
can drive an unauthenticated Unmanic through cross-site request forgery or DNS rebinding, and
a login screen does not stop that. So the cross-site protections went in alongside the login,
and are only active when authentication is enabled.

## How it works

Every request passes through one authorisation check, a `find_handler` override on the Tornado
application, rather than a decorator on each handler. That covers the REST API, the frontend,
static assets, the WebSocket handshake, the Swagger UI, and plugin handlers that are registered
at runtime. It also means a future endpoint cannot be left unprotected by forgetting to
decorate it. The unauthenticated allowlist is two routes, and the login and setup pages are
self-contained so no static path has to be opened up.

Browsers get a login page and a server-side session. The session token is 256 bits from
`secrets`, and only its SHA-256 is stored, so a leaked database contains nothing that can be
replayed. Sessions live in the existing SQLite database so a container update does not sign
everyone out, and carry a sliding idle timeout under an absolute cap. The cookie is `HttpOnly`
and `SameSite=Lax`, and only gets the `Secure` flag when TLS is enabled, because setting it
over plain HTTP would stop the cookie being sent at all and lock out every LAN user.

Passwords are hashed with `hashlib.scrypt` and stored as `scrypt$n$r$p$salt$hash` so the work
factors travel with the hash and can be raised later without a migration. That is stdlib, so
this PR adds no new dependency. Credentials are kept in the database rather than
`settings.json`, since that file gets pasted into bug reports and is returned wholesale by the
settings API.

API and script clients keep using HTTP Basic with the same credentials, which is what the
OpenAPI spec has always advertised and what `installation_link.py` already sends, so remote
installation links keep working with no changes and older versions can still link to a newer
authenticated one. A verified `Authorization` header is cached briefly so scrypt does not run
on every poll, which would otherwise be both slow and a way to burn CPU without logging in.
`WWW-Authenticate` is never sent in any response. That is deliberate: it stops browsers caching
Basic credentials, which would turn Basic into an ambient credential and a cross-site request
forgery vector.

Cross-site protection is three layers, all inactive unless authentication is enabled.
`SameSite=Lax` keeps the cookie off cross-site POSTs. An `Origin` check covers state-changing
requests, allowing an absent header so curl and instance-to-instance calls are unaffected, and
this is what closes DNS rebinding. Finally `Sec-Fetch-Site: cross-site` is rejected on the API,
plugin API and panel prefixes, because `SameSite=Lax` still attaches the cookie to top-level
GET navigation and browsers do not send `Origin` on those. An absent `Sec-Fetch-Site` is
allowed, which matters because browsers do not send it on WebSocket handshakes. UI routes are
left out of that check on purpose so the existing unmanic.app account flow, which returns
cross-site to `/unmanic/ui/trigger/`, keeps working.

Failed sign-ins are rate limited per client address with an escalating lockout, and logged at
warning level with the source address so fail2ban and similar tools have something to work
with.

A new installation needs no configuration at all: authentication is already on and the first
page load is the setup screen. For an existing installation there are three ways to turn it on,
to cover how people actually run Unmanic:
`unmanic --set-password` for pip installs and `docker exec`, the `auth_enabled`,
`auth_username` and `auth_password` environment variables for Docker, or a one-time setup page
served at `/unmanic/setup` when authentication is enabled before any credentials exist.
`unmanic --disable-auth` is the documented way back in if someone locks themselves out. The
environment variable password is hashed at startup and never written to `settings.json`.

Two new tables are added. They are created automatically by the existing schema sync in
`db_migrate.py`, which is why there is no migration script, and they are inert while the
feature is off.

## Notes for review

- **No existing installation changes behaviour.** The default is decided by whether a
  `settings.json` already exists. No file means a first run, so authentication is on and the
  first page load goes to the setup screen. A file that exists without the `auth_enabled` key
  means an upgrade, so it stays off and nothing is disturbed. Turning it on underneath a
  working installation would lock the owner out and break their remote instance links, which
  is not a decision an upgrade should make for someone. An explicit `auth_enabled` environment
  variable overrides both, and there are tests covering all three cases.
- **No new dependencies.** `requirements.txt` is untouched.
- **Single account, no roles.** Unmanic has no per-user data to separate, so multiple users
  would be a lot of code for separation the application cannot actually enforce. This was a
  deliberate choice rather than an oversight.
- **`api_schema_v2.json` is not updated in this PR.** Regenerating it against current apispec
  versions produces around 490 lines of unrelated changes on my machine, dropping
  `LibraryScanStatus` and the `metadata` and `pending/rescan` paths, because
  `requirements-dev.txt` pins `apispec>=6.3.1` with no upper bound. Committing that would look
  like deleting a large chunk of the API docs. The new endpoints do register correctly, and the
  file regenerates on startup in developer mode. Might be worth a separate look.
- **Tests.** Unit tests cover hashing, the session store, the origin and `Sec-Fetch-Site`
  rules, redirect target validation, and the lockout. Integration tests start a real server and
  check that every route shape refuses anonymous access, that sign in and sign out work end to
  end, that Basic can be enabled and disabled, that no response carries `WWW-Authenticate`, and
  that the WebSocket handshake is refused without a session and accepted with one. They drive
  the server over HTTP with `requests` rather than using `tornado.testing`, because
  `AsyncHTTPTestCase` does not collect under current pytest releases.
- **A couple of existing GET endpoints have side effects** (`session/logout`,
  `session/get_app_auth_code`, `docs/logs/zip`, and the `pending/download/*` link generators).
  The `Sec-Fetch-Site` layer covers them, but moving them to POST would be the real fix. That is
  a breaking API change so I have left it alone.
- **Windows.** `hashlib.scrypt` needs an OpenSSL-backed `hashlib`, which I expect is fine for
  the Windows installer but I have only been able to verify on Linux.
- **Flag naming.** `--set-password` and `--disable-auth` are unqualified and Unmanic already has
  an unmanic.app account concept. Happy to rename them to something like `--set-web-password`
  if you would prefer.

A follow-up PR against unmanic-frontend adds the sign out button to the toolbar and redirects
to the login page when a request returns 401. This PR does not depend on it: the login page is
served by the backend, so sign in and sign out both work on their own.
